### PR TITLE
Implement Eulen QR identity compliance

### DIFF
--- a/Atlas-API/prisma/migrations/20260615_add_eulen_withdrawal_polling.sql
+++ b/Atlas-API/prisma/migrations/20260615_add_eulen_withdrawal_polling.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "WithdrawalRequest"
+  ADD COLUMN IF NOT EXISTS "eulenNextPollAt" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "eulenPollAttempts" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "eulenRateLimitedAt" TIMESTAMP(3);
+
+CREATE INDEX IF NOT EXISTS "WithdrawalRequest_eulenNextPollAt_idx"
+  ON "WithdrawalRequest"("eulenNextPollAt");

--- a/Atlas-API/prisma/migrations/20260615_add_identity_vault.sql
+++ b/Atlas-API/prisma/migrations/20260615_add_identity_vault.sql
@@ -1,0 +1,135 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PayerIdentityStatus') THEN
+    CREATE TYPE "PayerIdentityStatus" AS ENUM ('UNKNOWN', 'VERIFIED', 'TRUSTED', 'FLAGGED', 'BLOCKED');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PayerRiskTier') THEN
+    CREATE TYPE "PayerRiskTier" AS ENUM ('UNKNOWN', 'LOW', 'MEDIUM', 'HIGH');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PayerMatchStatus') THEN
+    CREATE TYPE "PayerMatchStatus" AS ENUM ('UNKNOWN', 'MATCHED', 'MISMATCH', 'UNVERIFIABLE');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'IdentityVaultEventType') THEN
+    CREATE TYPE "IdentityVaultEventType" AS ENUM ('IDENTITY_CREATED', 'CONTACT_UPSERTED', 'PAYMENT_MATCHED', 'PAYMENT_MISMATCH', 'CONTACT_SEARCHED');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "PayerIdentity" (
+  "id" TEXT NOT NULL,
+  "euid" TEXT,
+  "euidHash" TEXT,
+  "taxNumberHash" TEXT,
+  "taxNumberMasked" TEXT,
+  "canonicalName" TEXT,
+  "searchName" TEXT,
+  "riskTier" "PayerRiskTier" NOT NULL DEFAULT 'UNKNOWN',
+  "status" "PayerIdentityStatus" NOT NULL DEFAULT 'UNKNOWN',
+  "medCount" INTEGER NOT NULL DEFAULT 0,
+  "lastSuccessfulPaymentAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "PayerIdentity_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "PayerIdentity_euid_key" ON "PayerIdentity"("euid");
+CREATE UNIQUE INDEX IF NOT EXISTS "PayerIdentity_euidHash_key" ON "PayerIdentity"("euidHash");
+CREATE UNIQUE INDEX IF NOT EXISTS "PayerIdentity_taxNumberHash_key" ON "PayerIdentity"("taxNumberHash");
+CREATE INDEX IF NOT EXISTS "PayerIdentity_taxNumberMasked_idx" ON "PayerIdentity"("taxNumberMasked");
+CREATE INDEX IF NOT EXISTS "PayerIdentity_status_lastSuccessfulPaymentAt_idx" ON "PayerIdentity"("status", "lastSuccessfulPaymentAt");
+CREATE INDEX IF NOT EXISTS "PayerIdentity_searchName_idx" ON "PayerIdentity"("searchName");
+
+CREATE TABLE IF NOT EXISTS "MerchantContact" (
+  "id" TEXT NOT NULL,
+  "merchantId" TEXT NOT NULL,
+  "identityId" TEXT NOT NULL,
+  "displayName" TEXT NOT NULL,
+  "searchName" TEXT NOT NULL,
+  "taxNumberMasked" TEXT,
+  "taxNumberSearchTokens" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "status" "PayerIdentityStatus" NOT NULL DEFAULT 'VERIFIED',
+  "paymentCount" INTEGER NOT NULL DEFAULT 0,
+  "lastTransactionId" TEXT,
+  "lastSuccessfulPaymentAt" TIMESTAMP(3),
+  "deletedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "MerchantContact_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "MerchantContact_merchantId_identityId_key" ON "MerchantContact"("merchantId", "identityId");
+CREATE INDEX IF NOT EXISTS "MerchantContact_merchantId_status_searchName_idx" ON "MerchantContact"("merchantId", "status", "searchName");
+CREATE INDEX IF NOT EXISTS "MerchantContact_merchantId_lastSuccessfulPaymentAt_idx" ON "MerchantContact"("merchantId", "lastSuccessfulPaymentAt");
+CREATE INDEX IF NOT EXISTS "MerchantContact_merchantId_deletedAt_idx" ON "MerchantContact"("merchantId", "deletedAt");
+CREATE INDEX IF NOT EXISTS "MerchantContact_taxNumberSearchTokens_idx" ON "MerchantContact" USING GIN ("taxNumberSearchTokens");
+
+CREATE TABLE IF NOT EXISTS "IdentityVaultEvent" (
+  "id" TEXT NOT NULL,
+  "identityId" TEXT,
+  "merchantId" TEXT,
+  "contactId" TEXT,
+  "transactionId" TEXT,
+  "type" "IdentityVaultEventType" NOT NULL,
+  "details" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "IdentityVaultEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "IdentityVaultEvent_identityId_createdAt_idx" ON "IdentityVaultEvent"("identityId", "createdAt");
+CREATE INDEX IF NOT EXISTS "IdentityVaultEvent_merchantId_createdAt_idx" ON "IdentityVaultEvent"("merchantId", "createdAt");
+CREATE INDEX IF NOT EXISTS "IdentityVaultEvent_transactionId_idx" ON "IdentityVaultEvent"("transactionId");
+CREATE INDEX IF NOT EXISTS "IdentityVaultEvent_type_createdAt_idx" ON "IdentityVaultEvent"("type", "createdAt");
+
+ALTER TABLE "Transaction"
+  ADD COLUMN IF NOT EXISTS "expectedPayerIdentityId" TEXT,
+  ADD COLUMN IF NOT EXISTS "actualPayerIdentityId" TEXT,
+  ADD COLUMN IF NOT EXISTS "merchantContactId" TEXT,
+  ADD COLUMN IF NOT EXISTS "payerMatchStatus" "PayerMatchStatus",
+  ADD COLUMN IF NOT EXISTS "payerTaxNumberHash" TEXT,
+  ADD COLUMN IF NOT EXISTS "payerTaxNumberMasked" TEXT,
+  ADD COLUMN IF NOT EXISTS "payerEuidHash" TEXT;
+
+ALTER TABLE "PaymentLinkSession"
+  ADD COLUMN IF NOT EXISTS "payerFullName" TEXT,
+  ADD COLUMN IF NOT EXISTS "payerIdentityId" TEXT,
+  ADD COLUMN IF NOT EXISTS "merchantContactId" TEXT,
+  ADD COLUMN IF NOT EXISTS "expectedPayerTaxNumberHash" TEXT,
+  ADD COLUMN IF NOT EXISTS "expectedPayerTaxNumberMasked" TEXT,
+  ADD COLUMN IF NOT EXISTS "expectedPayerEuidHash" TEXT,
+  ADD COLUMN IF NOT EXISTS "payerMatchStatus" "PayerMatchStatus";
+
+CREATE INDEX IF NOT EXISTS "Transaction_userId_merchantContactId_idx" ON "Transaction"("userId", "merchantContactId");
+CREATE INDEX IF NOT EXISTS "Transaction_userId_actualPayerIdentityId_createdAt_idx" ON "Transaction"("userId", "actualPayerIdentityId", "createdAt");
+CREATE INDEX IF NOT EXISTS "Transaction_payerMatchStatus_status_createdAt_idx" ON "Transaction"("payerMatchStatus", "status", "createdAt");
+CREATE INDEX IF NOT EXISTS "PaymentLinkSession_merchantContactId_idx" ON "PaymentLinkSession"("merchantContactId");
+CREATE INDEX IF NOT EXISTS "PaymentLinkSession_payerIdentityId_idx" ON "PaymentLinkSession"("payerIdentityId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'MerchantContact_merchantId_fkey') THEN
+    ALTER TABLE "MerchantContact" ADD CONSTRAINT "MerchantContact_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'MerchantContact_identityId_fkey') THEN
+    ALTER TABLE "MerchantContact" ADD CONSTRAINT "MerchantContact_identityId_fkey" FOREIGN KEY ("identityId") REFERENCES "PayerIdentity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Transaction_expectedPayerIdentityId_fkey') THEN
+    ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_expectedPayerIdentityId_fkey" FOREIGN KEY ("expectedPayerIdentityId") REFERENCES "PayerIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Transaction_actualPayerIdentityId_fkey') THEN
+    ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_actualPayerIdentityId_fkey" FOREIGN KEY ("actualPayerIdentityId") REFERENCES "PayerIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Transaction_merchantContactId_fkey') THEN
+    ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_merchantContactId_fkey" FOREIGN KEY ("merchantContactId") REFERENCES "MerchantContact"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'IdentityVaultEvent_identityId_fkey') THEN
+    ALTER TABLE "IdentityVaultEvent" ADD CONSTRAINT "IdentityVaultEvent_identityId_fkey" FOREIGN KEY ("identityId") REFERENCES "PayerIdentity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'IdentityVaultEvent_merchantId_fkey') THEN
+    ALTER TABLE "IdentityVaultEvent" ADD CONSTRAINT "IdentityVaultEvent_merchantId_fkey" FOREIGN KEY ("merchantId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'IdentityVaultEvent_contactId_fkey') THEN
+    ALTER TABLE "IdentityVaultEvent" ADD CONSTRAINT "IdentityVaultEvent_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "MerchantContact"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'IdentityVaultEvent_transactionId_fkey') THEN
+    ALTER TABLE "IdentityVaultEvent" ADD CONSTRAINT "IdentityVaultEvent_transactionId_fkey" FOREIGN KEY ("transactionId") REFERENCES "Transaction"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/Atlas-API/prisma/schema.prisma
+++ b/Atlas-API/prisma/schema.prisma
@@ -90,6 +90,8 @@ model User {
 
   // Sistema de Colateral
   collateralTransactions  CollateralTransaction[]      // Histórico de transações de colateral
+  merchantContacts        MerchantContact[]
+  identityVaultEvents     IdentityVaultEvent[]
 
   @@index([email])
   @@index([username])
@@ -115,6 +117,13 @@ model Transaction {
   payerTaxNumber String?          // CPF/CNPJ do pagador
   payerTaxNumberType PixKeyType?   // Tipo do documento (CPF ou CNPJ)
   metadata      String?
+  expectedPayerIdentityId String?
+  actualPayerIdentityId   String?
+  merchantContactId       String?
+  payerMatchStatus        PayerMatchStatus?
+  payerTaxNumberHash      String?
+  payerTaxNumberMasked    String?
+  payerEuidHash           String?
   errorMessage  String?
   processedAt   DateTime?
   splitFeeApplied Float?          // Taxa de split fee aplicada nesta transação (em %)
@@ -124,6 +133,10 @@ model Transaction {
   auditLogs     AuditLog[]
   user          User              @relation(fields: [userId], references: [id])
   webhookEvents WebhookEvent[]
+  expectedPayerIdentity PayerIdentity? @relation("ExpectedPayerIdentity", fields: [expectedPayerIdentityId], references: [id])
+  actualPayerIdentity   PayerIdentity? @relation("ActualPayerIdentity", fields: [actualPayerIdentityId], references: [id])
+  merchantContact       MerchantContact? @relation(fields: [merchantContactId], references: [id])
+  identityVaultEvents   IdentityVaultEvent[]
 
   @@index([userId])
   @@index([status])
@@ -131,6 +144,9 @@ model Transaction {
   @@index([externalId])
   @@index([createdAt])
   @@index([payerTaxNumber])
+  @@index([userId, merchantContactId])
+  @@index([userId, actualPayerIdentityId, createdAt])
+  @@index([payerMatchStatus, status, createdAt])
 }
 
 model WebhookEvent {
@@ -283,6 +299,13 @@ model PaymentLinkSession {
   sessionToken      String       @unique
   payerTaxNumber    String?
   payerTaxNumberType PixKeyType?
+  payerFullName      String?
+  payerIdentityId    String?
+  merchantContactId  String?
+  expectedPayerTaxNumberHash String?
+  expectedPayerTaxNumberMasked String?
+  expectedPayerEuidHash String?
+  payerMatchStatus   PayerMatchStatus?
   amount            Float?
   qrCode            String?
   qrCodeGeneratedAt DateTime?
@@ -294,6 +317,78 @@ model PaymentLinkSession {
   @@index([sessionToken])
   @@index([paymentLinkId])
   @@index([expiresAt])
+  @@index([merchantContactId])
+  @@index([payerIdentityId])
+}
+
+model PayerIdentity {
+  id                      String              @id @default(uuid())
+  euid                    String?             @unique
+  euidHash                String?             @unique
+  taxNumberHash           String?             @unique
+  taxNumberMasked         String?
+  canonicalName           String?
+  searchName              String?
+  riskTier                PayerRiskTier       @default(UNKNOWN)
+  status                  PayerIdentityStatus @default(UNKNOWN)
+  medCount                Int                 @default(0)
+  lastSuccessfulPaymentAt DateTime?
+  createdAt               DateTime            @default(now())
+  updatedAt               DateTime            @updatedAt
+  merchantContacts        MerchantContact[]
+  expectedTransactions    Transaction[]       @relation("ExpectedPayerIdentity")
+  actualTransactions      Transaction[]       @relation("ActualPayerIdentity")
+  events                  IdentityVaultEvent[]
+
+  @@index([taxNumberMasked])
+  @@index([status, lastSuccessfulPaymentAt])
+  @@index([searchName])
+}
+
+model MerchantContact {
+  id                      String              @id @default(uuid())
+  merchantId              String
+  identityId              String
+  displayName             String
+  searchName              String
+  taxNumberMasked         String?
+  taxNumberSearchTokens   String[]            @default([])
+  status                  PayerIdentityStatus @default(VERIFIED)
+  paymentCount            Int                 @default(0)
+  lastTransactionId       String?
+  lastSuccessfulPaymentAt DateTime?
+  deletedAt               DateTime?
+  createdAt               DateTime            @default(now())
+  updatedAt               DateTime            @updatedAt
+  merchant                User                @relation(fields: [merchantId], references: [id], onDelete: Cascade)
+  identity                PayerIdentity       @relation(fields: [identityId], references: [id], onDelete: Cascade)
+  transactions            Transaction[]
+  events                  IdentityVaultEvent[]
+
+  @@unique([merchantId, identityId])
+  @@index([merchantId, status, searchName])
+  @@index([merchantId, lastSuccessfulPaymentAt])
+  @@index([merchantId, deletedAt])
+}
+
+model IdentityVaultEvent {
+  id            String                 @id @default(uuid())
+  identityId    String?
+  merchantId    String?
+  contactId     String?
+  transactionId String?
+  type          IdentityVaultEventType
+  details       Json?
+  createdAt     DateTime               @default(now())
+  identity      PayerIdentity?          @relation(fields: [identityId], references: [id], onDelete: SetNull)
+  merchant      User?                   @relation(fields: [merchantId], references: [id], onDelete: SetNull)
+  contact       MerchantContact?        @relation(fields: [contactId], references: [id], onDelete: SetNull)
+  transaction   Transaction?            @relation(fields: [transactionId], references: [id], onDelete: SetNull)
+
+  @@index([identityId, createdAt])
+  @@index([merchantId, createdAt])
+  @@index([transactionId])
+  @@index([type, createdAt])
 }
 
 model PaymentLinkWebhook {
@@ -398,6 +493,9 @@ model WithdrawalRequest {
   eulenPayoutAmountCents  Int?
   eulenStatus             String?
   eulenSplits             Json?
+  eulenNextPollAt         DateTime?
+  eulenPollAttempts       Int              @default(0)
+  eulenRateLimitedAt      DateTime?
   receiptData             Json?
   excessAmount            Float?
   createdAt               DateTime         @default(now())
@@ -411,6 +509,7 @@ model WithdrawalRequest {
   @@index([method])
   @@index([depixReceiveAddress])
   @@index([eulenWithdrawalId])
+  @@index([eulenNextPollAt])
 }
 
 model SystemSettings {
@@ -615,6 +714,36 @@ enum TransactionStatus {
   FAILED
   CANCELLED
   EXPIRED
+}
+
+enum PayerIdentityStatus {
+  UNKNOWN
+  VERIFIED
+  TRUSTED
+  FLAGGED
+  BLOCKED
+}
+
+enum PayerRiskTier {
+  UNKNOWN
+  LOW
+  MEDIUM
+  HIGH
+}
+
+enum PayerMatchStatus {
+  UNKNOWN
+  MATCHED
+  MISMATCH
+  UNVERIFIABLE
+}
+
+enum IdentityVaultEventType {
+  IDENTITY_CREATED
+  CONTACT_UPSERTED
+  PAYMENT_MATCHED
+  PAYMENT_MISMATCH
+  CONTACT_SEARCHED
 }
 
 enum PixKeyType {

--- a/Atlas-API/src/account-validation/account-validation.controller.ts
+++ b/Atlas-API/src/account-validation/account-validation.controller.ts
@@ -27,8 +27,11 @@ class CreateValidationPaymentDto {
 	@IsOptional()
 	depixAddress?: string;
 
-	// Note: Tax number/EUID will be automatically extracted from webhook
-	// when user completes the PIX payment
+	@IsString()
+	taxNumber: string;
+
+	@IsString()
+	fullName: string;
 }
 
 class AdjustUserLimitsDto {
@@ -111,6 +114,8 @@ export class AccountValidationController {
 		return this.accountValidationService.createValidationPayment(
 			req.user.id,
 			dto.depixAddress,
+			dto.taxNumber,
+			dto.fullName,
 		);
 	}
 

--- a/Atlas-API/src/account-validation/account-validation.service.ts
+++ b/Atlas-API/src/account-validation/account-validation.service.ts
@@ -6,6 +6,8 @@ import { LiquidValidationService } from '../services/liquid-validation.service';
 import { EuidValidationService } from '../risk/euid-validation.service';
 import { RiskScoringService } from '../risk/risk-scoring.service';
 import { TransactionStatus, TransactionType, RiskEventType } from '@prisma/client';
+import { validateTaxNumber } from '../payment-link/utils/tax-number-validator';
+import { maskTaxNumber } from '../identity-vault/identity-vault.utils';
 
 @Injectable()
 export class AccountValidationService {
@@ -127,12 +129,29 @@ export class AccountValidationService {
 	async createValidationPayment(
 		userId: string,
 		depixAddress?: string,
+		taxNumber?: string,
+		fullName?: string,
 	): Promise<{
 		transactionId: string;
 		qrCode: string;
 		amount: number;
 	}> {
 		const validationAmount = await this.getValidationAmount();
+
+		const taxValidation = validateTaxNumber(taxNumber || '');
+		if (!taxValidation.isValid) {
+			throw new HttpException(
+				'CPF/CNPJ é obrigatório para validação de conta.',
+				HttpStatus.BAD_REQUEST,
+			);
+		}
+
+		if (!fullName?.trim()) {
+			throw new HttpException(
+				'Nome completo é obrigatório para validação de conta.',
+				HttpStatus.BAD_REQUEST,
+			);
+		}
 
 		// CRITICAL: depixAddress is REQUIRED for validation payments
 		// Without it, the DePix tokens would go to the system wallet instead of the user's wallet
@@ -185,11 +204,16 @@ export class AccountValidationService {
 			const metadata = existingValidation.metadata
 				? JSON.parse(existingValidation.metadata)
 				: {};
+			const requestedTaxNumberMasked = maskTaxNumber(taxValidation.formatted);
+			const requestedFullName = fullName.trim();
 
 			// Check if the existing QR code is valid (should be a string and not empty/true/false)
 			const storedQrCode = metadata.qrCode;
 			const isValidQrCode =
-				typeof storedQrCode === 'string' && storedQrCode.length > 10;
+				typeof storedQrCode === 'string' &&
+				storedQrCode.length > 10 &&
+				metadata.payerTaxNumberMasked === requestedTaxNumberMasked &&
+				metadata.payerFullName === requestedFullName;
 
 			if (isValidQrCode) {
 				this.logger.log(
@@ -222,10 +246,13 @@ export class AccountValidationService {
 				amount: validationAmount,
 				depixAddress: depixAddress, // Pass user's Liquid address so payment goes to them
 				description: 'Validação de conta Atlas DAO',
-				// Note: No payerCpfCnpj restriction - EUID will come from webhook
+				payerTaxNumber: taxValidation.formatted,
+				payerFullName: fullName.trim(),
 				metadata: {
 					isValidation: true,
 					userLiquidAddress: depixAddress, // Store user's Liquid address in metadata for reference
+					payerTaxNumberMasked: maskTaxNumber(taxValidation.formatted),
+					payerFullName: fullName.trim(),
 				},
 			});
 
@@ -257,6 +284,8 @@ export class AccountValidationService {
 							qrCode: qrCodeData.qrCode,
 							isValidation: true,
 							userLiquidAddress: depixAddress, // Store the user's Liquid address for later use
+							payerTaxNumberMasked: maskTaxNumber(taxValidation.formatted),
+							payerFullName: fullName.trim(),
 						}),
 					},
 				});
@@ -378,6 +407,48 @@ export class AccountValidationService {
 		// Extract EUID from webhook metadata if available
 		const webhookMetadata = metadata.webhookEvent;
 		const verifiedEUID = webhookMetadata?.payerEUID;
+		const webhookTaxNumber = webhookMetadata?.payerTaxNumber;
+		const webhookTaxNumberMasked = webhookTaxNumber?.includes('*')
+			? webhookTaxNumber
+			: maskTaxNumber(webhookTaxNumber);
+
+		if (!verifiedEUID || !webhookTaxNumberMasked) {
+			await this.prisma.transaction.update({
+				where: { id: transactionId },
+				data: {
+					status: TransactionStatus.FAILED,
+					errorMessage: 'Validation payment missing payer identity from Eulen',
+					metadata: JSON.stringify({
+						...metadata,
+						validationFailed: true,
+						validationError: !verifiedEUID ? 'EUID_MISSING' : 'TAX_NUMBER_MISSING',
+					}),
+				},
+			});
+			return;
+		}
+
+		if (
+			metadata.payerTaxNumberMasked &&
+			webhookTaxNumberMasked &&
+			metadata.payerTaxNumberMasked !== webhookTaxNumberMasked
+		) {
+			await this.prisma.transaction.update({
+				where: { id: transactionId },
+				data: {
+					status: TransactionStatus.FAILED,
+					errorMessage: 'Validation payment payer document mismatch',
+					metadata: JSON.stringify({
+						...metadata,
+						validationFailed: true,
+						validationError: 'TAX_NUMBER_MISMATCH',
+						expectedPayerTaxNumberMasked: metadata.payerTaxNumberMasked,
+						actualPayerTaxNumberMasked: webhookTaxNumberMasked,
+					}),
+				},
+			});
+			return;
+		}
 
 		// Extract liquid wallet address from transaction metadata
 		const userLiquidAddress = metadata.userLiquidAddress;

--- a/Atlas-API/src/app.module.ts
+++ b/Atlas-API/src/app.module.ts
@@ -24,6 +24,7 @@ import { RiskModule } from './risk/risk.module';
 import { ReferralModule } from './referral/referral.module';
 import { CollateralModule } from './collateral/collateral.module';
 import { WalletModule } from './wallet/wallet.module';
+import { IdentityVaultModule } from './identity-vault/identity-vault.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ServicesModule } from './services/services.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
@@ -42,6 +43,7 @@ import { IsNotDisposableEmailConstraint } from './common/decorators/email-valida
 			envFilePath: '.env',
 		}),
 		PrismaModule,
+		IdentityVaultModule,
 		ServicesModule,
 		HealthModule,
 		AuthModule,

--- a/Atlas-API/src/common/interceptors/audit.interceptor.ts
+++ b/Atlas-API/src/common/interceptors/audit.interceptor.ts
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Request, Response } from 'express';
 import { AuditLogRepository } from '../../repositories/audit-log.repository';
+import { redactSensitiveData } from '../utils/sensitive-redaction.util';
 
 @Injectable()
 export class AuditInterceptor implements NestInterceptor {
@@ -133,25 +134,7 @@ export class AuditInterceptor implements NestInterceptor {
 
 	private sanitizeBody(body: any): any {
 		if (!body) return null;
-
-		const sanitized = { ...body };
-		const sensitiveFields = [
-			'password',
-			'token',
-			'apiKey',
-			'secret',
-			'authorization',
-			'creditCard',
-			'cvv',
-		];
-
-		for (const field of sensitiveFields) {
-			if (sanitized[field]) {
-				sanitized[field] = '[REDACTED]';
-			}
-		}
-
-		return sanitized;
+		return redactSensitiveData(body);
 	}
 
 	private sanitizeResponse(data: any): any {
@@ -163,6 +146,6 @@ export class AuditInterceptor implements NestInterceptor {
 			return { _truncated: true, _size: stringified.length };
 		}
 
-		return data;
+		return redactSensitiveData(data);
 	}
 }

--- a/Atlas-API/src/common/interceptors/logging.interceptor.ts
+++ b/Atlas-API/src/common/interceptors/logging.interceptor.ts
@@ -12,6 +12,7 @@ import { tap } from 'rxjs/operators';
 import { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { HealthService } from '../../health/health.service';
+import { redactSensitiveData } from '../utils/sensitive-redaction.util';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -90,22 +91,6 @@ export class LoggingInterceptor implements NestInterceptor {
 
 	private sanitizeBody(body: any): any {
 		if (!body) return body;
-
-		const sanitized = { ...body };
-		const sensitiveFields = [
-			'password',
-			'token',
-			'apiKey',
-			'secret',
-			'authorization',
-		];
-
-		for (const field of sensitiveFields) {
-			if (sanitized[field]) {
-				sanitized[field] = '[REDACTED]';
-			}
-		}
-
-		return sanitized;
+		return redactSensitiveData(body);
 	}
 }

--- a/Atlas-API/src/common/utils/sensitive-redaction.util.ts
+++ b/Atlas-API/src/common/utils/sensitive-redaction.util.ts
@@ -1,0 +1,29 @@
+const SENSITIVE_KEY_PATTERN =
+	/(password|token|apikey|api_key|secret|authorization|creditcard|cvv|taxnumber|cpf|cnpj|payercpfcnpj|payertaxnumber|endusertaxnumber|euid|payereuid|merchantid)/i;
+
+export function redactSensitiveData<T = any>(value: T): T {
+	if (value === null || value === undefined) return value;
+
+	if (Array.isArray(value)) {
+		return value.map((item) => redactSensitiveData(item)) as T;
+	}
+
+	if (typeof value === 'object') {
+		const output: Record<string, any> = {};
+		for (const [key, nestedValue] of Object.entries(value as Record<string, any>)) {
+			output[key] = SENSITIVE_KEY_PATTERN.test(key)
+				? '[REDACTED]'
+				: redactSensitiveData(nestedValue);
+		}
+		return output as T;
+	}
+
+	if (typeof value === 'string') {
+		return value
+			.replace(/\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/g, '[REDACTED_CPF]')
+			.replace(/\b\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}\b/g, '[REDACTED_CNPJ]')
+			.replace(/\bEU[A-Z0-9]{8,}\b/gi, '[REDACTED_EUID]') as T;
+	}
+
+	return value;
+}

--- a/Atlas-API/src/external-api/dto/create-pix.dto.ts
+++ b/Atlas-API/src/external-api/dto/create-pix.dto.ts
@@ -90,13 +90,21 @@ export class CreatePixDto {
   @MaxLength(200)
   description?: string;
 
-  @ApiPropertyOptional({
-    description: 'Tax number (CPF/CNPJ) - required for amounts >= R$ 3000',
-    example: '123.456.789-01',
-  })
-  @IsOptional()
-  @IsString()
-  taxNumber?: string;
+	@ApiPropertyOptional({
+		description: 'Tax number (CPF/CNPJ) of the payer - required for all QR codes',
+		example: '123.456.789-01',
+	})
+	@IsOptional()
+	@IsString()
+	taxNumber?: string;
+
+	@ApiPropertyOptional({
+		description: 'Full legal name of the payer - required when no saved EUID is available',
+		example: 'Rafael Vieira da Rocha',
+	})
+	@IsOptional()
+	@IsString()
+	fullName?: string;
 
   @ApiPropertyOptional({
     description: 'Your internal order ID for tracking',

--- a/Atlas-API/src/external-api/external-api.controller.ts
+++ b/Atlas-API/src/external-api/external-api.controller.ts
@@ -56,9 +56,12 @@ export class ExternalApiController {
       throw new BadRequestException('Amount must be greater than 0');
     }
 
-    // taxNumber is required only for amounts >= 3000 BRL
-    if (body.amount >= 3000 && !body.taxNumber) {
-      throw new BadRequestException('Tax number (CPF/CNPJ) is required for amounts equal to or above R$ 3000');
+    if (!body.taxNumber) {
+      throw new BadRequestException('Tax number (CPF/CNPJ) is required for all QR codes');
+    }
+
+    if (!body.fullName) {
+      throw new BadRequestException('Full payer name is required for all QR codes without a saved EUID');
     }
 
     return this.externalApiService.createPixTransaction(userId, apiKeyId, body);

--- a/Atlas-API/src/external-api/external-api.service.ts
+++ b/Atlas-API/src/external-api/external-api.service.ts
@@ -11,6 +11,10 @@ import { TransactionStatus, TransactionType } from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 import { CreatePixDto } from './dto/create-pix.dto';
 import { ExternalWebhookService } from './external-webhook.service';
+import {
+  hashTaxNumber,
+  maskTaxNumber,
+} from '../identity-vault/identity-vault.utils';
 
 @Injectable()
 export class ExternalApiService {
@@ -79,12 +83,14 @@ export class ExternalApiService {
           depixAddress: depixAddress,
           description: data.description || 'Pagamento via API',
           isApiRequest: true, // Bypass tier limits for External API requests
-          payerCpfCnpj: data.taxNumber, // Forward tax number to Eulen API (required for amounts >= R$ 3000)
+          payerTaxNumber: data.taxNumber,
+          payerFullName: data.fullName,
           metadata: {
             source: 'EXTERNAL_API',
             apiKeyRequestId: apiKeyRequest.id,
             merchantOrderId: merchantOrderId,
-            taxNumber: data.taxNumber,
+            payerTaxNumberMasked: maskTaxNumber(data.taxNumber),
+            payerTaxNumberHash: hashTaxNumber(data.taxNumber),
             webhookUrl: data.webhookUrl || data.webhook?.url, // Support both formats
             ...data.metadata,
           },

--- a/Atlas-API/src/identity-vault/identity-vault.controller.ts
+++ b/Atlas-API/src/identity-vault/identity-vault.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { getEffectiveUserId } from '../common/decorators/effective-user.decorator';
+import {
+	IdentityVaultService,
+	MerchantContactSuggestion,
+} from './identity-vault.service';
+
+@ApiTags('Identity Vault')
+@Controller('identity-vault')
+export class IdentityVaultController {
+	constructor(private readonly identityVaultService: IdentityVaultService) {}
+
+	@Get('contacts/search')
+	@UseGuards(JwtAuthGuard)
+	@ApiBearerAuth()
+	@ApiOperation({ summary: 'Search merchant-scoped payer contacts' })
+	@ApiQuery({ name: 'q', required: true })
+	async searchContacts(
+		@Req() req: any,
+		@Query('q') query: string,
+	): Promise<MerchantContactSuggestion[]> {
+		const merchantId = getEffectiveUserId(req);
+		return this.identityVaultService.searchMerchantContacts(merchantId, query || '');
+	}
+}

--- a/Atlas-API/src/identity-vault/identity-vault.module.ts
+++ b/Atlas-API/src/identity-vault/identity-vault.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { IdentityVaultController } from './identity-vault.controller';
+import { IdentityVaultService } from './identity-vault.service';
+
+@Global()
+@Module({
+	imports: [PrismaModule],
+	controllers: [IdentityVaultController],
+	providers: [IdentityVaultService],
+	exports: [IdentityVaultService],
+})
+export class IdentityVaultModule {}

--- a/Atlas-API/src/identity-vault/identity-vault.service.ts
+++ b/Atlas-API/src/identity-vault/identity-vault.service.ts
@@ -1,0 +1,403 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+	IdentityVaultEventType,
+	PayerIdentityStatus,
+	PayerMatchStatus,
+	PayerRiskTier,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+	buildTaxNumberSearchToken,
+	buildTaxNumberSearchTokens,
+	hashEuid,
+	hashTaxNumber,
+	maskTaxNumber,
+	matchesTaxNumber,
+	normalizeEuid,
+	normalizeSearchName,
+	normalizeTaxNumber,
+} from './identity-vault.utils';
+
+export interface MerchantContactSuggestion {
+	id: string;
+	displayName: string;
+	taxNumberMasked: string | null;
+	lastSuccessfulPaymentAt: Date | null;
+	status: PayerIdentityStatus;
+}
+
+export interface InternalMerchantContact {
+	id: string;
+	displayName: string;
+	taxNumberMasked: string | null;
+	identity: {
+		id: string;
+		euid: string | null;
+		taxNumberHash: string | null;
+		taxNumberMasked: string | null;
+		canonicalName: string | null;
+		status: PayerIdentityStatus;
+	};
+}
+
+@Injectable()
+export class IdentityVaultService {
+	private readonly logger = new Logger(IdentityVaultService.name);
+
+	constructor(private readonly prisma: PrismaService) {}
+
+	async searchMerchantContacts(
+		merchantId: string,
+		query: string,
+		limit = 10,
+	): Promise<MerchantContactSuggestion[]> {
+		const searchName = normalizeSearchName(query);
+		const taxToken = buildTaxNumberSearchToken(query);
+
+		if (!searchName && !taxToken) return [];
+
+		const contacts = await this.prisma.merchantContact.findMany({
+			where: {
+				merchantId,
+				deletedAt: null,
+				OR: [
+					...(searchName
+						? [
+								{
+									searchName: {
+										contains: searchName,
+										mode: 'insensitive' as const,
+									},
+								},
+							]
+						: []),
+					...(taxToken
+						? [
+								{
+									taxNumberSearchTokens: {
+										has: taxToken,
+									},
+								},
+							]
+						: []),
+				],
+			},
+			orderBy: [{ lastSuccessfulPaymentAt: 'desc' }, { displayName: 'asc' }],
+			take: Math.min(Math.max(limit, 1), 20),
+		});
+
+		return contacts.map((contact) => ({
+			id: contact.id,
+			displayName: contact.displayName,
+			taxNumberMasked: contact.taxNumberMasked,
+			lastSuccessfulPaymentAt: contact.lastSuccessfulPaymentAt,
+			status: contact.status,
+		}));
+	}
+
+	async findMerchantContactByTaxNumber(
+		merchantId: string,
+		taxNumber: string,
+	): Promise<InternalMerchantContact | null> {
+		const taxNumberHash = hashTaxNumber(taxNumber);
+		if (!taxNumberHash) return null;
+
+		const contact = await this.prisma.merchantContact.findFirst({
+			where: {
+				merchantId,
+				deletedAt: null,
+				identity: { taxNumberHash },
+			},
+			include: { identity: true },
+		});
+
+		return contact as InternalMerchantContact | null;
+	}
+
+	async getMerchantContactForQr(
+		merchantId: string,
+		contactId: string,
+	): Promise<InternalMerchantContact | null> {
+		const contact = await this.prisma.merchantContact.findFirst({
+			where: {
+				id: contactId,
+				merchantId,
+				deletedAt: null,
+				status: { not: PayerIdentityStatus.BLOCKED },
+			},
+			include: { identity: true },
+		});
+
+		return contact as InternalMerchantContact | null;
+	}
+
+	async prepareNewPayerIdentity(input: {
+		merchantId: string;
+		taxNumber: string;
+		fullName: string;
+	}): Promise<{
+		taxNumberHash: string;
+		taxNumberMasked: string;
+		fullName: string;
+	}> {
+		const taxNumberHash = hashTaxNumber(input.taxNumber);
+		const taxNumberMasked = maskTaxNumber(input.taxNumber);
+		if (!taxNumberHash || !taxNumberMasked) {
+			throw new Error('Invalid tax number');
+		}
+
+		return {
+			taxNumberHash,
+			taxNumberMasked,
+			fullName: input.fullName.trim(),
+		};
+	}
+
+	async upsertMerchantContactFromPayment(input: {
+		merchantId: string;
+		transactionId?: string;
+		payerName?: string | null;
+		payerTaxNumber?: string | null;
+		payerEuid?: string | null;
+		expectedTaxNumber?: string | null;
+		expectedEuid?: string | null;
+	}): Promise<{
+		matchStatus: PayerMatchStatus;
+		contactId?: string;
+		identityId?: string;
+	}> {
+		const expectedEuid = normalizeEuid(input.expectedEuid);
+		const actualEuid = normalizeEuid(input.payerEuid);
+		let matchStatus: PayerMatchStatus = PayerMatchStatus.UNKNOWN;
+
+		if (expectedEuid && actualEuid) {
+			matchStatus =
+				expectedEuid === actualEuid
+					? PayerMatchStatus.MATCHED
+					: PayerMatchStatus.MISMATCH;
+		} else if (input.expectedTaxNumber) {
+			const taxMatch = matchesTaxNumber(
+				input.expectedTaxNumber,
+				input.payerTaxNumber,
+			);
+			if (taxMatch === true) matchStatus = PayerMatchStatus.MATCHED;
+			else if (taxMatch === false) matchStatus = PayerMatchStatus.MISMATCH;
+			else matchStatus = PayerMatchStatus.UNVERIFIABLE;
+		}
+
+		const actualTaxNumberHash = hashTaxNumber(input.payerTaxNumber);
+		const actualTaxNumberMasked =
+			maskTaxNumber(input.payerTaxNumber) ||
+			(input.payerTaxNumber?.includes('*') ? input.payerTaxNumber : null);
+		const actualEuidHash = hashEuid(actualEuid);
+
+		if (matchStatus === PayerMatchStatus.MISMATCH) {
+			await this.updateTransactionIdentity(input.transactionId, {
+				payerMatchStatus: matchStatus,
+				payerTaxNumberHash: actualTaxNumberHash,
+				payerTaxNumberMasked: actualTaxNumberMasked,
+				payerEuidHash: actualEuidHash,
+			});
+			await this.createEvent({
+				type: IdentityVaultEventType.PAYMENT_MISMATCH,
+				merchantId: input.merchantId,
+				transactionId: input.transactionId,
+				details: {
+					expectedEuidHash: hashEuid(expectedEuid),
+					actualEuidHash,
+					expectedTaxNumberHash: hashTaxNumber(input.expectedTaxNumber),
+					actualTaxNumberHash,
+				},
+			});
+			return { matchStatus };
+		}
+
+		const identity = await this.upsertIdentity({
+			euid: actualEuid,
+			taxNumberHash: actualTaxNumberHash,
+			taxNumberMasked: actualTaxNumberMasked,
+			canonicalName: input.payerName || undefined,
+			status:
+				matchStatus === PayerMatchStatus.UNVERIFIABLE
+					? PayerIdentityStatus.UNKNOWN
+					: PayerIdentityStatus.VERIFIED,
+		});
+
+		const contact = await this.upsertMerchantContact({
+			merchantId: input.merchantId,
+			identityId: identity.id,
+			displayName:
+				input.payerName ||
+				identity.canonicalName ||
+				`Pagador ${actualTaxNumberMasked || ''}`.trim(),
+			taxNumberMasked: actualTaxNumberMasked,
+			taxNumber: input.payerTaxNumber || input.expectedTaxNumber || undefined,
+			transactionId: input.transactionId,
+		});
+
+		await this.updateTransactionIdentity(input.transactionId, {
+			actualPayerIdentityId: identity.id,
+			merchantContactId: contact.id,
+			payerMatchStatus: matchStatus,
+			payerTaxNumberHash: actualTaxNumberHash,
+			payerTaxNumberMasked: actualTaxNumberMasked,
+			payerEuidHash: actualEuidHash,
+			buyerName: input.payerName || undefined,
+		});
+
+		await this.createEvent({
+			type: IdentityVaultEventType.PAYMENT_MATCHED,
+			identityId: identity.id,
+			merchantId: input.merchantId,
+			contactId: contact.id,
+			transactionId: input.transactionId,
+			details: { matchStatus },
+		});
+
+		return {
+			matchStatus,
+			contactId: contact.id,
+			identityId: identity.id,
+		};
+	}
+
+	private async upsertIdentity(input: {
+		euid?: string | null;
+		taxNumberHash?: string | null;
+		taxNumberMasked?: string | null;
+		canonicalName?: string;
+		status?: PayerIdentityStatus;
+	}) {
+		const euid = normalizeEuid(input.euid);
+		const euidHash = hashEuid(euid);
+		const where = [
+			...(input.taxNumberHash ? [{ taxNumberHash: input.taxNumberHash }] : []),
+			...(euidHash ? [{ euidHash }] : []),
+		];
+
+		const existing = where.length
+			? await this.prisma.payerIdentity.findFirst({ where: { OR: where } })
+			: null;
+
+		const data = {
+			euid,
+			euidHash,
+			taxNumberHash: input.taxNumberHash,
+			taxNumberMasked: input.taxNumberMasked,
+			canonicalName: input.canonicalName,
+			searchName: normalizeSearchName(input.canonicalName),
+			status: input.status || PayerIdentityStatus.UNKNOWN,
+			riskTier: PayerRiskTier.UNKNOWN,
+			lastSuccessfulPaymentAt: new Date(),
+		};
+
+		if (existing) {
+			return this.prisma.payerIdentity.update({
+				where: { id: existing.id },
+				data: {
+					euid: existing.euid || data.euid,
+					euidHash: existing.euidHash || data.euidHash,
+					taxNumberHash: existing.taxNumberHash || data.taxNumberHash,
+					taxNumberMasked: existing.taxNumberMasked || data.taxNumberMasked,
+					canonicalName: data.canonicalName || existing.canonicalName,
+					searchName: data.searchName || existing.searchName,
+					status:
+						existing.status === PayerIdentityStatus.UNKNOWN
+							? data.status
+							: existing.status,
+					lastSuccessfulPaymentAt: data.lastSuccessfulPaymentAt,
+				},
+			});
+		}
+
+		const created = await this.prisma.payerIdentity.create({ data });
+		await this.createEvent({
+			type: IdentityVaultEventType.IDENTITY_CREATED,
+			identityId: created.id,
+			details: {
+				hasTaxNumberHash: Boolean(created.taxNumberHash),
+				hasEuidHash: Boolean(created.euidHash),
+			},
+		});
+		return created;
+	}
+
+	private async upsertMerchantContact(input: {
+		merchantId: string;
+		identityId: string;
+		displayName: string;
+		taxNumberMasked?: string | null;
+		taxNumber?: string;
+		transactionId?: string;
+	}) {
+		const existing = await this.prisma.merchantContact.findUnique({
+			where: {
+				merchantId_identityId: {
+					merchantId: input.merchantId,
+					identityId: input.identityId,
+				},
+			},
+		});
+
+		const data = {
+			displayName: input.displayName.trim(),
+			searchName: normalizeSearchName(input.displayName),
+			taxNumberMasked: input.taxNumberMasked,
+			taxNumberSearchTokens: buildTaxNumberSearchTokens(input.taxNumber),
+			lastTransactionId: input.transactionId,
+			lastSuccessfulPaymentAt: new Date(),
+			deletedAt: null,
+			status: PayerIdentityStatus.VERIFIED,
+		};
+
+		if (existing) {
+			return this.prisma.merchantContact.update({
+				where: { id: existing.id },
+				data: {
+					...data,
+					taxNumberMasked: data.taxNumberMasked || existing.taxNumberMasked,
+					taxNumberSearchTokens:
+						data.taxNumberSearchTokens.length > 0
+							? data.taxNumberSearchTokens
+							: existing.taxNumberSearchTokens,
+					paymentCount: { increment: 1 },
+				},
+			});
+		}
+
+		return this.prisma.merchantContact.create({
+			data: {
+				merchantId: input.merchantId,
+				identityId: input.identityId,
+				...data,
+				paymentCount: 1,
+			},
+		});
+	}
+
+	private async updateTransactionIdentity(
+		transactionId: string | undefined,
+		data: Record<string, any>,
+	) {
+		if (!transactionId) return;
+		await this.prisma.transaction.update({
+			where: { id: transactionId },
+			data,
+		});
+	}
+
+	private async createEvent(input: {
+		type: IdentityVaultEventType;
+		identityId?: string;
+		merchantId?: string;
+		contactId?: string;
+		transactionId?: string;
+		details?: Record<string, any>;
+	}) {
+		try {
+			await this.prisma.identityVaultEvent.create({ data: input });
+		} catch (error) {
+			this.logger.warn(`Failed to create identity vault event: ${error.message}`);
+		}
+	}
+}

--- a/Atlas-API/src/identity-vault/identity-vault.utils.spec.ts
+++ b/Atlas-API/src/identity-vault/identity-vault.utils.spec.ts
@@ -1,0 +1,40 @@
+import {
+	buildTaxNumberSearchToken,
+	buildTaxNumberSearchTokens,
+	hashTaxNumber,
+	maskTaxNumber,
+	matchesTaxNumber,
+	normalizeSearchName,
+} from './identity-vault.utils';
+
+describe('identity-vault utils', () => {
+	beforeEach(() => {
+		process.env.IDENTITY_HASH_SECRET = 'test-secret';
+	});
+
+	it('normalizes search names and masks CPF/CNPJ without storing full documents', () => {
+		expect(normalizeSearchName('Rafael Vieira da Rocha')).toBe(
+			'rafael vieira da rocha',
+		);
+		expect(maskTaxNumber('123.456.789-01')).toBe('123.***.***-01');
+		expect(maskTaxNumber('12.345.678/0001-99')).toBe('12.***.***/****-99');
+	});
+
+	it('hashes equivalent formatted and unformatted tax numbers identically', () => {
+		expect(hashTaxNumber('123.456.789-01')).toBe(hashTaxNumber('12345678901'));
+	});
+
+	it('creates hashed search tokens for merchant-scoped partial document search', () => {
+		const tokens = buildTaxNumberSearchTokens('12345678901');
+		expect(tokens).toContain(buildTaxNumberSearchToken('1234'));
+		expect(tokens).toContain(buildTaxNumberSearchToken('7890'));
+	});
+
+	it('compares full and censored payer documents when enough digits are visible', () => {
+		expect(matchesTaxNumber('12345678901', '12345678901')).toBe(true);
+		expect(matchesTaxNumber('12345678901', '123.***.***-01')).toBe(true);
+		expect(matchesTaxNumber('12345678901', '***.456.789-**')).toBe(true);
+		expect(matchesTaxNumber('12345678901', '987.***.***-01')).toBe(false);
+		expect(matchesTaxNumber('12345678901', '***')).toBeNull();
+	});
+});

--- a/Atlas-API/src/identity-vault/identity-vault.utils.ts
+++ b/Atlas-API/src/identity-vault/identity-vault.utils.ts
@@ -1,0 +1,106 @@
+import { createHmac } from 'crypto';
+
+const DEFAULT_HASH_SECRET = 'zapix-development-identity-hash-secret';
+
+export function getIdentityHashSecret(): string {
+	return (
+		process.env.IDENTITY_HASH_SECRET ||
+		process.env.JWT_SECRET ||
+		process.env.ENCRYPTION_KEY ||
+		DEFAULT_HASH_SECRET
+	);
+}
+
+export function normalizeTaxNumber(value?: string | null): string {
+	return (value || '').replace(/\D/g, '');
+}
+
+export function normalizeEuid(value?: string | null): string | null {
+	const trimmed = (value || '').trim();
+	return trimmed ? trimmed.toUpperCase() : null;
+}
+
+export function normalizeSearchName(value?: string | null): string {
+	return (value || '')
+		.normalize('NFD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.toLowerCase()
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+export function hashIdentityValue(value?: string | null): string | null {
+	const normalized = (value || '').trim();
+	if (!normalized) return null;
+
+	return createHmac('sha256', getIdentityHashSecret())
+		.update(normalized)
+		.digest('hex');
+}
+
+export function hashTaxNumber(value?: string | null): string | null {
+	const normalized = normalizeTaxNumber(value);
+	return normalized ? hashIdentityValue(normalized) : null;
+}
+
+export function hashEuid(value?: string | null): string | null {
+	const normalized = normalizeEuid(value);
+	return normalized ? hashIdentityValue(normalized) : null;
+}
+
+export function maskTaxNumber(value?: string | null): string | null {
+	const digits = normalizeTaxNumber(value);
+	if (digits.length === 11) {
+		return `${digits.slice(0, 3)}.***.***-${digits.slice(9, 11)}`;
+	}
+	if (digits.length === 14) {
+		return `${digits.slice(0, 2)}.***.***/****-${digits.slice(12, 14)}`;
+	}
+	return null;
+}
+
+export function buildTaxNumberSearchTokens(value?: string | null): string[] {
+	const digits = normalizeTaxNumber(value);
+	if (digits.length < 3) return [];
+
+	const tokens = new Set<string>();
+	for (let length = 3; length <= Math.min(digits.length, 11); length++) {
+		for (let start = 0; start + length <= digits.length; start++) {
+			const hash = hashIdentityValue(digits.slice(start, start + length));
+			if (hash) tokens.add(hash);
+		}
+	}
+
+	return Array.from(tokens);
+}
+
+export function buildTaxNumberSearchToken(query?: string | null): string | null {
+	const digits = normalizeTaxNumber(query);
+	if (digits.length < 3) return null;
+	return hashIdentityValue(digits);
+}
+
+export function matchesTaxNumber(expected?: string | null, actual?: string | null): boolean | null {
+	const expectedDigits = normalizeTaxNumber(expected);
+	if (expectedDigits.length !== 11 && expectedDigits.length !== 14) return null;
+
+	const actualRaw = actual || '';
+	const actualDigits = normalizeTaxNumber(actualRaw);
+	if (actualDigits.length === expectedDigits.length) {
+		return actualDigits === expectedDigits;
+	}
+
+	if (actualRaw.includes('*')) {
+		const expectedMasked = maskTaxNumber(expectedDigits);
+		if (expectedMasked && expectedMasked === actualRaw) return true;
+
+		// Eulen may return censored documents with only the visible digits.
+		if (actualDigits.length >= 4) {
+			return expectedDigits.includes(actualDigits);
+		}
+
+		return null;
+	}
+
+	return null;
+}

--- a/Atlas-API/src/payment-link/dto/payment-link.dto.ts
+++ b/Atlas-API/src/payment-link/dto/payment-link.dto.ts
@@ -233,6 +233,14 @@ export class GenerateQRWithTaxNumberDto {
 		message: 'CPF/CNPJ inválido. Use apenas números ou formatos: 000.000.000-00 (CPF) ou 00.000.000/0000-00 (CNPJ)',
 	})
 	taxNumber: string;
+
+	@ApiPropertyOptional({
+		description: 'Nome completo do pagador quando ainda não há contato/EUID salvo',
+		example: 'Rafael Vieira da Rocha',
+	})
+	@IsString()
+	@IsOptional()
+	fullName?: string;
 }
 
 export class GenerateQRCodeDto {
@@ -255,4 +263,7 @@ export class QRCodeResponseDto {
 	requiresTaxNumber?: boolean;
 	sessionToken?: string;
 	needsTaxNumber?: boolean;
+	needsFullName?: boolean;
+	contactFound?: boolean;
+	payerNameHint?: string;
 }

--- a/Atlas-API/src/payment-link/payment-link.service.ts
+++ b/Atlas-API/src/payment-link/payment-link.service.ts
@@ -9,6 +9,12 @@ import {
 } from './dto/payment-link.dto';
 import { PixService } from '../pix/pix.service';
 import { WebhookService } from './webhook.service';
+import { IdentityVaultService } from '../identity-vault/identity-vault.service';
+import {
+	hashEuid,
+	hashTaxNumber,
+	maskTaxNumber,
+} from '../identity-vault/identity-vault.utils';
 import { nanoid } from 'nanoid';
 import { validateTaxNumber } from './utils/tax-number-validator';
 import { PixKeyType } from '@prisma/client';
@@ -21,6 +27,7 @@ export class PaymentLinkService {
 		private readonly prisma: PrismaService,
 		private readonly pixService: PixService,
 		private readonly webhookService: WebhookService,
+		private readonly identityVaultService: IdentityVaultService,
 	) {}
 
 	async create(
@@ -488,7 +495,7 @@ export class PaymentLinkService {
 			where: { shortCode },
 			include: {
 				user: {
-					select: { commerceMode: true },
+					select: { commerceMode: true, verifiedTaxNumber: true },
 				},
 			},
 		});
@@ -559,83 +566,13 @@ export class PaymentLinkService {
 			amount = link.amount;
 		}
 
-		// Check if tax number is required
-		// CPF/CNPJ é SEMPRE obrigatório para valores acima de R$ 3.000,00
-		const TAX_NUMBER_THRESHOLD = 3000.00;
-		const needsTaxNumber = amount > TAX_NUMBER_THRESHOLD;
+		return {
+			qrCode: '',
+			expiresAt: new Date(),
+			transactionId: '',
+			needsTaxNumber: true,
+		};
 
-		if (needsTaxNumber) {
-			// Return indication that tax number is needed
-			return {
-				qrCode: '',
-				expiresAt: new Date(),
-				transactionId: '',
-				needsTaxNumber: true,
-			};
-		}
-
-		try {
-			// Generate PIX QR Code with paymentLinkId in metadata
-			this.logger.log(`🔗 PAYMENT LINK: Generating QR code for link ${link.id} (${link.shortCode})`);
-			this.logger.log(`  Amount: ${amount}, Wallet: ${link.walletAddress}`);
-
-			const metadata = {
-				paymentLinkId: link.id,
-				shortCode: link.shortCode,
-			};
-
-			this.logger.log(`  Metadata being passed: ${JSON.stringify(metadata)}`);
-
-			const qrCodeData = await this.pixService.generatePixQRCode(link.userId, {
-				amount,
-				depixAddress: link.walletAddress,
-				description: link.description || `Payment ${shortCode}`,
-				metadata,
-			});
-
-			// Update link with new QR code
-			const expiresAt = new Date(Date.now() + 28 * 60 * 1000); // 28 minutes from now
-
-			await this.prisma.paymentLink.update({
-				where: { id: link.id },
-				data: {
-					currentQrCode: qrCodeData.qrCode,
-					qrCodeGeneratedAt: new Date(),
-				},
-			});
-
-			// Trigger "payment.created" webhook
-			const webhookPayload = {
-				paymentLinkId: link.id,
-				shortCode: link.shortCode,
-				amount,
-				qrCode: qrCodeData.qrCode,
-				walletAddress: link.walletAddress,
-				description: link.description,
-				expiresAt: expiresAt.toISOString(),
-				generatedAt: new Date().toISOString(),
-			};
-
-			this.logger.log(`🎯 Triggering payment.created webhook for ${link.shortCode}`);
-
-			// Fire and forget - don't await so QR generation isn't slowed down
-			this.webhookService.triggerWebhooks(link.id, 'payment.created', webhookPayload)
-				.catch(error => {
-					this.logger.error('Webhook trigger failed:', error);
-				});
-
-			return {
-				qrCode: qrCodeData.qrCode,
-				expiresAt,
-				transactionId: qrCodeData.transactionId || '',
-			};
-		} catch (error) {
-			this.logger.error(`Failed to generate QR code for ${shortCode}:`, error);
-			throw new HttpException(
-				'Failed to generate QR code',
-				HttpStatus.INTERNAL_SERVER_ERROR,
-			);
-		}
 	}
 
 	async generateQRCodeWithTaxNumber(
@@ -711,6 +648,23 @@ export class PaymentLinkService {
 			);
 		}
 
+		const contact = await this.identityVaultService.findMerchantContactByTaxNumber(
+			link.userId,
+			taxValidation.formatted,
+		);
+		const fullName = dto.fullName?.trim();
+
+		if (!contact?.identity?.euid && !fullName) {
+			return {
+				qrCode: '',
+				expiresAt: new Date(),
+				transactionId: '',
+				needsFullName: true,
+				contactFound: Boolean(contact),
+				payerNameHint: contact?.displayName,
+			};
+		}
+
 		try {
 			// Create payment session
 			const sessionToken = nanoid(32);
@@ -722,6 +676,14 @@ export class PaymentLinkService {
 					sessionToken,
 					payerTaxNumber: taxValidation.formatted,
 					payerTaxNumberType: taxValidation.type === 'CPF' ? PixKeyType.CPF : PixKeyType.CNPJ,
+					payerFullName: fullName || contact?.displayName,
+					payerIdentityId: contact?.identity?.id,
+					merchantContactId: contact?.id,
+					expectedPayerTaxNumberHash: hashTaxNumber(taxValidation.formatted),
+					expectedPayerTaxNumberMasked: maskTaxNumber(taxValidation.formatted),
+					expectedPayerEuidHash: contact?.identity?.euid
+						? hashEuid(contact.identity.euid)
+						: null,
 					amount,
 					expiresAt,
 				},
@@ -734,8 +696,11 @@ export class PaymentLinkService {
 			const metadata = {
 				paymentLinkId: link.id,
 				shortCode: link.shortCode,
-				payerTaxNumber: taxValidation.formatted,
+				payerTaxNumberMasked: maskTaxNumber(taxValidation.formatted),
+				payerTaxNumberHash: hashTaxNumber(taxValidation.formatted),
 				sessionToken,
+				merchantContactId: contact?.id,
+				expectedPayerIdentityId: contact?.identity?.id,
 			};
 
 			const qrCodeData = await this.pixService.generatePixQRCode(link.userId, {
@@ -743,8 +708,9 @@ export class PaymentLinkService {
 				depixAddress: link.walletAddress,
 				description: link.description || `Pagamento ${shortCode}`,
 				metadata,
-				// This will be passed to Eulen API as userTaxNumber
-				payerCpfCnpj: taxValidation.formatted,
+				payerContactId: contact?.identity?.euid ? contact.id : undefined,
+				payerTaxNumber: contact?.identity?.euid ? undefined : taxValidation.formatted,
+				payerFullName: contact?.identity?.euid ? undefined : fullName,
 			});
 
 			// Update session with QR code
@@ -775,9 +741,7 @@ export class PaymentLinkService {
 				description: link.description,
 				expiresAt: expiresAt.toISOString(),
 				generatedAt: new Date().toISOString(),
-				payerTaxNumber: taxValidation.type === 'CPF' ?
-					`***.${taxValidation.formatted.slice(3, 6)}.${taxValidation.formatted.slice(6, 9)}-**` :
-					`**.***.***/****-${taxValidation.formatted.slice(12, 14)}`,
+				payerTaxNumber: maskTaxNumber(taxValidation.formatted),
 				payerTaxNumberType: taxValidation.type,
 			};
 
@@ -794,6 +758,7 @@ export class PaymentLinkService {
 				expiresAt,
 				transactionId: qrCodeData.transactionId || '',
 				sessionToken,
+				contactFound: Boolean(contact),
 			};
 		} catch (error) {
 			this.logger.error(`Failed to generate QR code with tax number for ${shortCode}:`, error);
@@ -807,18 +772,33 @@ export class PaymentLinkService {
 		}
 	}
 
-	async checkPaymentStatus(transactionId: string): Promise<{ status: string; paid: boolean }> {
+	async checkPaymentStatus(shortCode: string, transactionId: string): Promise<{ status: string; paid: boolean }> {
 		try {
+			const link = await this.prisma.paymentLink.findUnique({
+				where: { shortCode },
+				select: { id: true, userId: true },
+			});
+
+			if (!link) {
+				return { status: 'not_found', paid: false };
+			}
+
 			const transaction = await this.prisma.transaction.findFirst({
 				where: {
 					OR: [
 						{ id: transactionId },
 						{ externalId: transactionId },
 					],
+					userId: link.userId,
 				},
 			});
 
 			if (!transaction) {
+				return { status: 'not_found', paid: false };
+			}
+
+			const metadata = transaction.metadata ? JSON.parse(transaction.metadata) : {};
+			if (metadata.paymentLinkId !== link.id && metadata.shortCode !== shortCode) {
 				return { status: 'not_found', paid: false };
 			}
 

--- a/Atlas-API/src/payment-link/public-payment-link.controller.ts
+++ b/Atlas-API/src/payment-link/public-payment-link.controller.ts
@@ -68,6 +68,6 @@ export class PublicPaymentLinkController {
 		@Param('shortCode') shortCode: string,
 		@Param('transactionId') transactionId: string,
 	): Promise<{ status: string; paid: boolean }> {
-		return this.paymentLinkService.checkPaymentStatus(transactionId);
+		return this.paymentLinkService.checkPaymentStatus(shortCode, transactionId);
 	}
 }

--- a/Atlas-API/src/pix/pix.controller.ts
+++ b/Atlas-API/src/pix/pix.controller.ts
@@ -201,6 +201,10 @@ export class PixController {
 			description?: string;
 			expirationMinutes?: number;
 			isCommerceRequest?: boolean; // Flag to indicate if request is from commerce page
+			payerContactId?: string; // Existing merchant contact, already linked to an EUID
+			payerTaxNumber?: string; // CPF/CNPJ for a new payer identity
+			payerFullName?: string; // Full legal name for a new payer identity
+			payerCpfCnpj?: string; // Legacy alias kept for older clients
 		},
 	) {
 		const userId = getEffectiveUserId(req);

--- a/Atlas-API/src/pix/pix.service.ts
+++ b/Atlas-API/src/pix/pix.service.ts
@@ -13,13 +13,19 @@ import { TransactionRepository } from '../repositories/transaction.repository';
 import { AuditLogRepository } from '../repositories/audit-log.repository';
 import { PrismaService } from '../prisma/prisma.service';
 import { LevelsService } from '../levels/levels.service';
+import { IdentityVaultService } from '../identity-vault/identity-vault.service';
+import {
+	hashEuid,
+	hashTaxNumber,
+	maskTaxNumber,
+} from '../identity-vault/identity-vault.utils';
 import {
 	DepositDto,
 	WithdrawDto,
 	TransferDto,
 	TransactionResponseDto,
 } from '../eulen/dto/eulen.dto';
-import { TransactionType, TransactionStatus } from '@prisma/client';
+import { PayerMatchStatus, TransactionType, TransactionStatus } from '@prisma/client';
 import * as QRCode from 'qrcode';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -40,6 +46,7 @@ export class PixService {
 		private readonly auditLogRepository: AuditLogRepository,
 		private readonly prisma: PrismaService,
 		private readonly levelsService: LevelsService,
+		private readonly identityVaultService: IdentityVaultService,
 	) {}
 
 	/**
@@ -365,6 +372,9 @@ export class PixService {
 			description?: string;
 			expirationMinutes?: number;
 			payerCpfCnpj?: string; // CPF/CNPJ do pagador (para modo comércio)
+			payerTaxNumber?: string;
+			payerFullName?: string;
+			payerContactId?: string;
 			metadata?: any; // Additional metadata to store with the transaction
 			isApiRequest?: boolean; // Whether this request is from API (via x-api-key header)
 			isCommerceRequest?: boolean; // Whether this request is from commerce page (not deposit page)
@@ -419,6 +429,67 @@ export class PixService {
 				// If present, it will be used as EUID in the Eulen API call below
 			}
 
+			const merchantEuid = this.isEuid(user.verifiedTaxNumber)
+				? user.verifiedTaxNumber
+				: undefined;
+			const isCommerceQr =
+				user.commerceMode === true ||
+				data.isCommerceRequest === true ||
+				Boolean(isPaymentLink);
+			let payerTaxNumber = data.payerTaxNumber || data.payerCpfCnpj;
+			let payerFullName = data.payerFullName?.trim();
+			let payerEuid: string | undefined;
+			let expectedPayerIdentityId: string | undefined;
+			let merchantContactId: string | undefined;
+
+			if (data.payerContactId) {
+				const contact = await this.identityVaultService.getMerchantContactForQr(
+					userId,
+					data.payerContactId,
+				);
+				if (!contact) {
+					throw new HttpException(
+						'Contato do pagador não encontrado para este merchant.',
+						HttpStatus.BAD_REQUEST,
+					);
+				}
+				if (!contact.identity.euid) {
+					throw new HttpException(
+						'Contato ainda não possui EUID verificado. Informe CPF/CNPJ e nome completo para gerar o QR.',
+						HttpStatus.BAD_REQUEST,
+					);
+				}
+				payerEuid = contact.identity.euid;
+				payerFullName = contact.displayName;
+				expectedPayerIdentityId = contact.identity.id;
+				merchantContactId = contact.id;
+			}
+
+			if (!payerEuid && !payerTaxNumber && !isCommerceQr && merchantEuid) {
+				payerEuid = merchantEuid;
+			}
+
+			if (isCommerceQr && !isValidationPayment && !merchantEuid) {
+				throw new HttpException(
+					'Merchant sem EUID validado. Valide a conta antes de gerar QR de comércio.',
+					HttpStatus.FORBIDDEN,
+				);
+			}
+
+			if (!payerEuid && !payerTaxNumber) {
+				throw new HttpException(
+					'Identificação do pagador é obrigatória para gerar QR Code.',
+					HttpStatus.BAD_REQUEST,
+				);
+			}
+
+			if (!payerEuid && payerTaxNumber && !payerFullName) {
+				throw new HttpException(
+					'Nome completo do pagador é obrigatório quando o CPF/CNPJ ainda não possui EUID.',
+					HttpStatus.BAD_REQUEST,
+				);
+			}
+
 			// Apply limits based on the REQUEST CONTEXT (not just user attributes)
 			if (!isValidationPayment) {
 				// Check if user is making an API request via x-api-key header
@@ -444,9 +515,9 @@ export class PixService {
 				} else if (isCommerceManualQR && user.commerceMode) {
 					// COMMERCE MANUAL QR CODE (from /commerce page): Apply commerce-specific limits, NO level limits
 					// Minimum: 1 BRL
-					// Maximum: 3000 BRL (without CPF/CNPJ) or 5000 BRL (with CPF/CNPJ)
+					// Maximum: 5000 BRL after payer identity is provided.
 					const minAmount = 1;
-					const maxAmount = data.payerCpfCnpj ? 5000 : 3000;
+					const maxAmount = 5000;
 
 					if (data.amount < minAmount) {
 						throw new HttpException(
@@ -456,23 +527,22 @@ export class PixService {
 					}
 
 					if (data.amount > maxAmount) {
-						const limitType = data.payerCpfCnpj ? 'com CPF/CNPJ' : 'sem CPF/CNPJ';
 						throw new HttpException(
-							`Valor máximo por transação no modo comércio ${limitType}: R$ ${maxAmount.toFixed(2)}`,
+							`Valor máximo por transação no modo comércio identificado: R$ ${maxAmount.toFixed(2)}`,
 							HttpStatus.FORBIDDEN
 						);
 					}
 
 					this.logger.log(
 						`✅ Commerce manual QR validation passed for user ${userId}: ` +
-						`Amount: R$ ${data.amount.toFixed(2)}, Limit: R$ ${maxAmount.toFixed(2)} (${data.payerCpfCnpj ? 'with' : 'without'} CPF/CNPJ) - NO level limits enforced`
+						`Amount: R$ ${data.amount.toFixed(2)}, Limit: R$ ${maxAmount.toFixed(2)} (identified payer) - NO level limits enforced`
 					);
 				} else if (isPaymentLink && user.commerceMode) {
 					// PAYMENT LINKS (Commerce feature): Apply commerce-specific limits
 					// Minimum: 1 BRL
-					// Maximum: 3000 BRL (without CPF/CNPJ) or 5000 BRL (with CPF/CNPJ)
+					// Maximum: 5000 BRL after payer identity is provided.
 					const minAmount = 1;
-					const maxAmount = data.payerCpfCnpj ? 5000 : 3000;
+					const maxAmount = 5000;
 
 					if (data.amount < minAmount) {
 						throw new HttpException(
@@ -482,16 +552,15 @@ export class PixService {
 					}
 
 					if (data.amount > maxAmount) {
-						const limitType = data.payerCpfCnpj ? 'com CPF/CNPJ' : 'sem CPF/CNPJ';
 						throw new HttpException(
-							`Valor máximo por transação no modo comércio ${limitType}: R$ ${maxAmount.toFixed(2)}`,
+							`Valor máximo por transação no modo comércio identificado: R$ ${maxAmount.toFixed(2)}`,
 							HttpStatus.FORBIDDEN
 						);
 					}
 
 					this.logger.log(
 						`✅ Commerce payment link validation passed for user ${userId}: ` +
-						`Amount: R$ ${data.amount.toFixed(2)}, Limit: R$ ${maxAmount.toFixed(2)} (${data.payerCpfCnpj ? 'with' : 'without'} CPF/CNPJ)`
+						`Amount: R$ ${data.amount.toFixed(2)}, Limit: R$ ${maxAmount.toFixed(2)} (identified payer)`
 					);
 				} else {
 					// PANEL /DEPOSIT PAGE: Apply level-based limits for ALL users
@@ -570,41 +639,15 @@ export class PixService {
 				}
 			}
 
-			// For personal deposits, only use verified tax number if it's not the problematic EUID
-			// For API requests, preserve the payerCpfCnpj provided by the caller (e.g. taxNumber from external API)
-			if (!data.metadata?.isValidation && !data.metadata?.paymentLinkId) { // Skip enforcement for validation payments and payment links
-				if (data.isApiRequest && data.payerCpfCnpj) {
-					// API request with explicit tax number - use it as-is
-					this.logger.log(`🔑 API request: Using provided taxNumber ${data.payerCpfCnpj} for user ${userId}`);
-				} else if (user.verifiedTaxNumber && user.verifiedTaxNumber !== 'EU022986123087767') {
-					data.payerCpfCnpj = user.verifiedTaxNumber; // Use verified tax number as EUID
-					this.logger.log(`🔒 Personal deposit: Using verified EUID ${user.verifiedTaxNumber} for user ${userId} (commerceMode: ${user.commerceMode})`);
-				} else {
-					data.payerCpfCnpj = undefined; // Don't send any EUID to avoid Eulen API rejection
-					this.logger.log(`🔄 Personal deposit: Skipping invalid/problematic EUID for user ${userId} - sending without userTaxNumber`);
+			if (payerTaxNumber) {
+				const cpfCnpjClean = payerTaxNumber.replace(/\D/g, '');
+				if (cpfCnpjClean.length !== 11 && cpfCnpjClean.length !== 14) {
+					throw new HttpException(
+						'CPF/CNPJ inválido. Use 11 dígitos para CPF ou 14 para CNPJ.',
+						HttpStatus.BAD_REQUEST,
+					);
 				}
-			}
-
-			// If commerce mode is enabled, allow multiple CPF/CNPJ
-			if (user?.commerceMode && data.payerCpfCnpj) {
-				// Check if it's EUID format (for Eulen API) or CPF/CNPJ format
-				const isEuidFormat = /^[a-zA-Z0-9]+$/.test(data.payerCpfCnpj) &&
-									 data.payerCpfCnpj.length >= 3 &&
-									 data.payerCpfCnpj.length <= 20 &&
-									 !/^\d+$/.test(data.payerCpfCnpj); // Not purely numeric
-
-				if (!isEuidFormat) {
-					// Validate traditional CPF/CNPJ format
-					const cpfCnpjClean = data.payerCpfCnpj.replace(/\D/g, '');
-					if (cpfCnpjClean.length !== 11 && cpfCnpjClean.length !== 14) {
-						throw new HttpException(
-							'CPF/CNPJ inválido. Use 11 dígitos para CPF ou 14 para CNPJ.',
-							HttpStatus.BAD_REQUEST,
-						);
-					}
-				} else {
-					this.logger.log(`✅ EUID format detected for commerce user: ${data.payerCpfCnpj}`);
-				}
+				payerTaxNumber = cpfCnpjClean;
 			}
 
 			// NOTE: depixAddress is now optional and should be a PIX key (CPF, CNPJ, email, phone, EVP)
@@ -615,7 +658,13 @@ export class PixService {
 				isQrCodePayment: true,
 				depixAddress: data.depixAddress, // Also store in metadata for reference
 				expirationMinutes: data.expirationMinutes || Math.floor((29 * 60 + 50) / 60), // 29 minutes 50 seconds
-				payerCpfCnpj: data.payerCpfCnpj, // Store payer CPF/CNPJ if provided
+				payerTaxNumberMasked: payerTaxNumber ? maskTaxNumber(payerTaxNumber) : undefined,
+				payerTaxNumberHash: payerTaxNumber ? hashTaxNumber(payerTaxNumber) : undefined,
+				hasPayerEuid: Boolean(payerEuid),
+				payerEuidHash: payerEuid ? hashEuid(payerEuid) : undefined,
+				expectedPayerIdentityId,
+				merchantContactId,
+				merchantId: isCommerceQr && !isValidationPayment ? merchantEuid : undefined,
 				...data.metadata, // Include any additional metadata (like paymentLinkId)
 			};
 
@@ -628,6 +677,13 @@ export class PixService {
 				amount: data.amount,
 				description: data.description || 'PIX QR Code Payment',
 				pixKey: data.depixAddress, // Store DePix address in pixKey field
+				buyerName: payerFullName,
+				expectedPayerIdentityId,
+				merchantContactId,
+				payerMatchStatus: PayerMatchStatus.UNKNOWN,
+				payerTaxNumberHash: payerTaxNumber ? hashTaxNumber(payerTaxNumber) : null,
+				payerTaxNumberMasked: payerTaxNumber ? maskTaxNumber(payerTaxNumber) : null,
+				payerEuidHash: payerEuid ? hashEuid(payerEuid) : null,
 				metadata: JSON.stringify(metadataToStore),
 			});
 
@@ -692,6 +748,10 @@ export class PixService {
 					amount: data.amount,
 					depixAddress: data.depixAddress,
 					description: data.description,
+					hasPayerEuid: Boolean(payerEuid),
+					hasPayerTaxNumber: Boolean(payerTaxNumber),
+					hasPayerFullName: Boolean(payerFullName),
+					merchantId: isCommerceQr && !isValidationPayment ? 'present' : 'not_applicable',
 					whitelist: isWhitelisted,
 					splitFee: splitFeeString || 'disabled (0%)',
 					depixSplitAddress: splitFeeString ? SPLIT_FEE_ADDRESS : 'N/A',
@@ -736,7 +796,10 @@ export class PixService {
 				amount: data.amount,
 				depixAddress: data.depixAddress, // Pass DePix address from frontend
 				description: data.description,
-				userTaxNumber: data.payerCpfCnpj, // Pass tax number as EUID
+				payerEuid,
+				payerFullName,
+				merchantId: isCommerceQr && !isValidationPayment ? merchantEuid : undefined,
+				userTaxNumber: payerTaxNumber,
 				whitelist: isWhitelisted, // Pass whitelist parameter to Eulen API
 				// Only send splitFee if percentage > 0 (Eulen API requires > 0% and < 20%)
 				splitFee: splitFeeString,
@@ -949,7 +1012,7 @@ export class PixService {
 
 					this.logger.log(`💰 PAYMENT COMPLETED!`);
 					this.logger.log(`👤 Payer Name: ${payerInfo.payerName}`);
-					this.logger.log(`📋 Payer Tax Number: ${payerInfo.payerTaxNumber}`);
+					this.logger.log(`📋 Payer Tax Number: ${maskTaxNumber(payerInfo.payerTaxNumber) || 'unavailable'}`);
 					this.logger.log(`🏦 Bank Transaction ID: ${payerInfo.bankTxId}`);
 					this.logger.log(
 						`⛓️ Blockchain Transaction ID: ${payerInfo.blockchainTxID}`,
@@ -978,14 +1041,42 @@ export class PixService {
 						const currentMetadata = transaction.metadata
 							? JSON.parse(transaction.metadata)
 							: {};
+						let payerMatchStatus = transaction.payerMatchStatus || PayerMatchStatus.UNKNOWN;
+						if (payerInfo.payerEUID || payerInfo.payerTaxNumber || payerInfo.payerName) {
+							const session = currentMetadata.sessionToken
+								? await this.prisma.paymentLinkSession.findUnique({
+										where: { sessionToken: currentMetadata.sessionToken },
+									})
+								: null;
+							const txWithContact = await this.prisma.transaction.findUnique({
+								where: { id: transaction.id },
+								include: { merchantContact: { include: { identity: true } } },
+							});
+							const identityResult = await this.identityVaultService.upsertMerchantContactFromPayment({
+								merchantId: transaction.userId,
+								transactionId: transaction.id,
+								payerName: payerInfo.payerName,
+								payerTaxNumber: payerInfo.payerTaxNumber,
+								payerEuid: payerInfo.payerEUID,
+								expectedTaxNumber: session?.payerTaxNumber,
+								expectedEuid: txWithContact?.merchantContact?.identity?.euid,
+							});
+							payerMatchStatus = identityResult.matchStatus;
+							if (payerMatchStatus === PayerMatchStatus.MISMATCH) {
+								newStatus = TransactionStatus.IN_REVIEW;
+								shouldStopPolling = false;
+							}
+						}
 						await this.transactionRepository.update(transaction.id, {
 							status: newStatus,
 							processedAt: new Date(),
 							buyerName: payerInfo.payerName, // Save payer name to buyerName field
+							payerMatchStatus,
 							metadata: JSON.stringify({
 								...currentMetadata,
 								payerInfo,
 								eulenResponse: eulenStatus.response,
+								payerMatchStatus,
 								completedAt: new Date().toISOString(),
 							}),
 						});
@@ -1234,6 +1325,10 @@ export class PixService {
 			default:
 				return 'Status desconhecido';
 		}
+	}
+
+	private isEuid(value?: string | null): value is string {
+		return /^EU[A-Z0-9]{8,}$/i.test(value || '');
 	}
 
 	private mapTransactionToResponse(transaction: any): TransactionResponseDto {

--- a/Atlas-API/src/repositories/audit-log.repository.ts
+++ b/Atlas-API/src/repositories/audit-log.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AuditLog, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AbstractBaseRepository } from './base.repository';
+import { redactSensitiveData } from '../common/utils/sensitive-redaction.util';
 
 @Injectable()
 export class AuditLogRepository extends AbstractBaseRepository<AuditLog> {
@@ -31,8 +32,8 @@ export class AuditLogRepository extends AbstractBaseRepository<AuditLog> {
 			data: {
 				...data,
 				userId: data.userId || null, // Allow null userId for system actions
-				requestBody: requestBody ? JSON.stringify(requestBody) : null,
-				responseBody: responseBody ? JSON.stringify(responseBody) : null,
+				requestBody: requestBody ? JSON.stringify(redactSensitiveData(requestBody)) : null,
+				responseBody: responseBody ? JSON.stringify(redactSensitiveData(responseBody)) : null,
 			},
 		});
 	}

--- a/Atlas-API/src/services/eulen-client.service.ts
+++ b/Atlas-API/src/services/eulen-client.service.ts
@@ -1,12 +1,15 @@
 import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios, { AxiosInstance, AxiosError } from 'axios';
-import { RateLimiterService } from './rate-limiter.service';
+import { EulenRateLimitError, RateLimiterService } from './rate-limiter.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { redactSensitiveData } from '../common/utils/sensitive-redaction.util';
 
 interface DepositRequest {
 	amountInCents: number;
 	depixAddress?: string;
+	euid?: string;
+	merchantId?: string;
 	endUserFullName?: string;
 	endUserTaxNumber?: string;
 	splitFee?: string; // Percentual da taxa (ex: "0.5%")
@@ -76,7 +79,7 @@ export class EulenClientService {
 				);
 				if (config.data) {
 					this.logger.log(
-						`📦 Request Body: ${JSON.stringify(config.data, null, 2)}`,
+						`📦 Request Body: ${JSON.stringify(redactSensitiveData(config.data), null, 2)}`,
 					);
 				}
 
@@ -101,12 +104,27 @@ export class EulenClientService {
 					`🔍 Response Headers: ${JSON.stringify(response.headers, null, 2)}`,
 				);
 				this.logger.log(
-					`📦 Response Body: ${JSON.stringify(response.data, null, 2)}`,
+					`📦 Response Body: ${JSON.stringify(redactSensitiveData(response.data), null, 2)}`,
 				);
 
 				return response;
 			},
 			(error: AxiosError) => {
+				if (this.isProviderRateLimit(error)) {
+					const endpoint = this.resolveEndpointName(error.config?.url);
+					const retryAfterMs = this.extractRetryAfterMs(error);
+					this.logger.warn(
+						`Eulen API rate limited ${endpoint}: retry after ${Math.ceil(retryAfterMs / 1000)}s`,
+					);
+					return Promise.reject(
+						new EulenRateLimitError(
+							endpoint,
+							retryAfterMs,
+							this.getProviderErrorMessage(error) || 'Eulen API rate limit',
+						),
+					);
+				}
+
 				// Detailed error logging
 				this.logger.error(`❌ EULEN API ERROR`);
 				this.logger.error(
@@ -117,7 +135,7 @@ export class EulenClientService {
 				);
 				if (error.response?.data) {
 					this.logger.error(
-						`📦 Error Response: ${JSON.stringify(error.response.data, null, 2)}`,
+						`📦 Error Response: ${JSON.stringify(redactSensitiveData(error.response.data), null, 2)}`,
 					);
 				}
 				this.logger.error(`🔍 Error Message: ${error.message}`);
@@ -237,6 +255,55 @@ export class EulenClientService {
 		}
 	}
 
+	private isProviderRateLimit(error: AxiosError): boolean {
+		const status = error.response?.status;
+		const message = this.getProviderErrorMessage(error).toLowerCase();
+		return (
+			status === 429 ||
+			(status === 520 && message.includes('too many requests')) ||
+			message.includes('rate limit')
+		);
+	}
+
+	private getProviderErrorMessage(error: AxiosError): string {
+		const data = error.response?.data as any;
+		return data?.response?.errorMessage || data?.message || error.message || '';
+	}
+
+	private extractRetryAfterMs(error: AxiosError): number {
+		const headers = error.response?.headers || {};
+		const retryAfter = headers['retry-after'] || headers['Retry-After'];
+		if (retryAfter) {
+			const retryAfterNumber = Number(retryAfter);
+			if (!Number.isNaN(retryAfterNumber)) {
+				return Math.max(retryAfterNumber * 1000, 0);
+			}
+
+			const retryAfterDate = Date.parse(String(retryAfter));
+			if (!Number.isNaN(retryAfterDate)) {
+				return Math.max(retryAfterDate - Date.now(), 0);
+			}
+		}
+
+		const message = this.getProviderErrorMessage(error);
+		const secondsMatch = message.match(/wait\s+(\d+)\s+(?:more\s+)?seconds?/i);
+		if (secondsMatch) {
+			return Number(secondsMatch[1]) * 1000;
+		}
+
+		return 60_000;
+	}
+
+	private resolveEndpointName(url?: string): string {
+		if (!url) return 'unknown';
+		if (url.includes('/withdraw-status')) return 'withdraw-status';
+		if (url.includes('/deposit-status')) return 'deposit-status';
+		if (url.includes('/withdraw')) return 'withdraw';
+		if (url.includes('/deposit')) return 'deposit';
+		if (url.includes('/ping')) return 'ping';
+		return url.replace(/^\//, '') || 'unknown';
+	}
+
 	/**
 	 * Ping endpoint - Basic connectivity check
 	 */
@@ -260,6 +327,8 @@ export class EulenClientService {
 		amount: number; // Amount in cents
 		pixKey: string; // DePix address (Liquid address)
 		description?: string;
+		euid?: string;
+		merchantId?: string;
 		userFullName?: string;
 		userTaxNumber?: string;
 		whitelist?: boolean; // Optional whitelist parameter to bypass first purchase limit
@@ -294,6 +363,16 @@ export class EulenClientService {
 					requestData.endUserFullName = data.userFullName;
 				}
 
+				if (data.euid) {
+					requestData.euid = data.euid;
+					this.logger.log(`✅ Including payer EUID for deposit`);
+				}
+
+				if (data.merchantId) {
+					requestData.merchantId = data.merchantId;
+					this.logger.log(`✅ Including merchantId for commerce deposit`);
+				}
+
 				// Add whitelist parameter if provided
 				if (data.whitelist === true) {
 					requestData.whitelist = true;
@@ -314,7 +393,7 @@ export class EulenClientService {
 				}
 
 				// Format and validate CPF/CNPJ
-				if (data.userTaxNumber) {
+				if (data.userTaxNumber && !data.euid) {
 					// Remove all non-numeric characters
 					const cleanedTaxNumber = data.userTaxNumber.replace(/\D/g, '');
 
@@ -326,12 +405,12 @@ export class EulenClientService {
 						this.logger.warn(`⚠️ Invalid tax number length: ${cleanedTaxNumber.length} digits (${data.userTaxNumber})`);
 						// Don't send invalid tax numbers
 					}
-				} else {
-					this.logger.log(`📋 No tax number provided - API will proceed without EUID restriction`);
+				} else if (!data.euid) {
+					this.logger.log(`📋 No tax number or payer EUID provided`);
 				}
 
 				this.logger.log(
-					`📤 Request Data: ${JSON.stringify(requestData, null, 2)}`,
+					`📤 Request Data: ${JSON.stringify(redactSensitiveData(requestData), null, 2)}`,
 				);
 				const response = await this.client.post<DepositResponse>(
 					'/deposit',
@@ -347,14 +426,18 @@ export class EulenClientService {
 					`🖼️ QR Image URL: ${response.data.response.qrImageUrl ? 'Generated' : 'Missing'}`,
 				);
 				this.logger.log(
-					`📦 Full Response: ${JSON.stringify(response.data, null, 2)}`,
+					`📦 Full Response: ${JSON.stringify(redactSensitiveData(response.data), null, 2)}`,
 				);
 
 				return response.data;
 			} catch (error) {
 				// Always throw errors - no more development mode fallbacks
 				// The real DePix API should be used in all environments
-				this.logger.error(`❌ Eulen API createDeposit failed: ${error.message}`);
+				if (this.rateLimiter.isRateLimitError(error)) {
+					this.logger.warn(`Eulen API createDeposit deferred by rate limit: ${error.message}`);
+				} else {
+					this.logger.error(`❌ Eulen API createDeposit failed: ${error.message}`);
+				}
 				throw error;
 			}
 		});
@@ -479,7 +562,11 @@ export class EulenClientService {
 					payoutAmountInCents: result.payoutAmountInCents || data.payoutAmountInCents,
 				};
 			} catch (error) {
-				this.logger.error(`❌ Eulen API createWithdraw failed: ${error.message}`);
+				if (this.rateLimiter.isRateLimitError(error)) {
+					this.logger.warn(`Eulen API createWithdraw deferred by rate limit: ${error.message}`);
+				} else {
+					this.logger.error(`❌ Eulen API createWithdraw failed: ${error.message}`);
+				}
 				throw error;
 			}
 		});
@@ -518,7 +605,11 @@ export class EulenClientService {
 					paidAt: result.paidAt,
 				};
 			} catch (error) {
-				this.logger.error(`❌ Eulen API getWithdrawStatus failed: ${error.message}`);
+				if (this.rateLimiter.isRateLimitError(error)) {
+					this.logger.warn(`Eulen API getWithdrawStatus deferred by rate limit: ${error.message}`);
+				} else {
+					this.logger.error(`❌ Eulen API getWithdrawStatus failed: ${error.message}`);
+				}
 				throw error;
 			}
 		});
@@ -552,6 +643,9 @@ export class EulenClientService {
 		amount: number; // Amount in REAIS
 		depixAddress?: string; // PIX key (CPF, CNPJ, email, phone, or EVP) - OPTIONAL
 		description?: string;
+		payerEuid?: string;
+		payerFullName?: string;
+		merchantId?: string;
 		userTaxNumber?: string; // Tax number (CPF/CNPJ) for EUID restriction
 		whitelist?: boolean; // Optional whitelist parameter to bypass first purchase limit
 		splitFee?: string; // Percentual da taxa (ex: "0.5%")
@@ -579,6 +673,9 @@ export class EulenClientService {
 				amount: amountInCents, // Already in cents
 				pixKey: data.depixAddress || '', // Use provided PIX key or empty string (API will use default)
 				description: data.description,
+				euid: data.payerEuid,
+				merchantId: data.merchantId,
+				userFullName: data.payerFullName,
 				userTaxNumber: data.userTaxNumber, // Pass tax number for EUID restriction
 				whitelist: data.whitelist, // Pass whitelist parameter to bypass first purchase limit
 				splitFee: data.splitFee, // Pass split fee percentage

--- a/Atlas-API/src/services/rate-limiter.service.spec.ts
+++ b/Atlas-API/src/services/rate-limiter.service.spec.ts
@@ -1,0 +1,38 @@
+import { EulenRateLimitError, RateLimiterService } from './rate-limiter.service';
+
+describe('RateLimiterService', () => {
+	let service: RateLimiterService;
+	let randomSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		service = new RateLimiterService();
+		randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+	});
+
+	afterEach(() => {
+		randomSpy.mockRestore();
+	});
+
+	it('opens an endpoint circuit after an Eulen rate-limit response', async () => {
+		await expect(
+			service.executeWithRateLimit('withdraw-status', async () => {
+				throw new EulenRateLimitError(
+					'withdraw-status',
+					60_000,
+					'Too many requests. Please wait 60 more seconds before retrying',
+				);
+			}),
+		).rejects.toMatchObject({
+			isEulenRateLimitError: true,
+			endpoint: 'withdraw-status',
+			retryAfterMs: 60_000,
+		});
+
+		await expect(
+			service.executeWithRateLimit('withdraw-status', async () => 'ok'),
+		).rejects.toMatchObject({
+			isEulenRateLimitError: true,
+			endpoint: 'withdraw-status',
+		});
+	});
+});

--- a/Atlas-API/src/services/rate-limiter.service.ts
+++ b/Atlas-API/src/services/rate-limiter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 interface RateLimitConfig {
 	endpoint: string;
@@ -16,8 +16,29 @@ interface RequestQueue {
 	queue: Array<() => Promise<any>>;
 }
 
+interface CircuitState {
+	openUntil: number;
+	strikes: number;
+	lastReason: string;
+	lastOpenedAt: number;
+}
+
+export class EulenRateLimitError extends Error {
+	readonly isEulenRateLimitError = true;
+
+	constructor(
+		readonly endpoint: string,
+		readonly retryAfterMs: number,
+		message = 'Eulen API rate limit reached',
+	) {
+		super(message);
+		this.name = 'EulenRateLimitError';
+	}
+}
+
 @Injectable()
 export class RateLimiterService {
+	private readonly logger = new Logger(RateLimiterService.name);
 	private readonly limits: RateLimitConfig[] = [
 		{
 			endpoint: 'ping',
@@ -37,9 +58,30 @@ export class RateLimiterService {
 			burstLimit: 20,
 			dailyLimit: 86400,
 		},
+		{
+			endpoint: 'withdraw',
+			rateLimit: 10,
+			burstLimit: 10,
+			dailyLimit: 5000,
+		},
+		{
+			endpoint: 'withdraw-status',
+			rateLimit: 1,
+			burstLimit: 1,
+			dailyLimit: 1440,
+		},
 	];
 
 	private requestQueues: Map<string, RequestQueue> = new Map();
+	private circuitBreakers: Map<string, CircuitState> = new Map();
+	private readonly defaultProviderRetryMs = this.getPositiveNumberFromEnv(
+		'EULEN_RATE_LIMIT_DEFAULT_RETRY_MS',
+		60_000,
+	);
+	private readonly maxProviderRetryMs = this.getPositiveNumberFromEnv(
+		'EULEN_RATE_LIMIT_MAX_RETRY_MS',
+		15 * 60_000,
+	);
 
 	constructor() {
 		// Initialize queues for each endpoint
@@ -77,6 +119,8 @@ export class RateLimiterService {
 		if (!queue) {
 			return fn();
 		}
+
+		this.assertCircuitClosed(endpoint);
 
 		// Check daily limit reset
 		const now = Date.now();
@@ -124,11 +168,21 @@ export class RateLimiterService {
 		queue.dailyCount++;
 
 		try {
-			return await fn();
+			const result = await fn();
+			this.closeCircuit(endpoint);
+			return result;
 		} catch (error) {
 			// If request fails, don't count it against limits
 			queue.requestCount--;
 			queue.dailyCount--;
+			if (this.isRateLimitError(error)) {
+				const retryAfterMs = this.openCircuit(endpoint, error);
+				throw new EulenRateLimitError(
+					endpoint,
+					retryAfterMs,
+					`Eulen rate limit for ${endpoint}. Next retry after ${Math.ceil(retryAfterMs / 1000)}s.`,
+				);
+			}
 			throw error;
 		}
 	}
@@ -141,6 +195,7 @@ export class RateLimiterService {
 		remaining: number;
 		resetTime: number;
 		dailyRemaining: number;
+		circuitOpenUntil?: number;
 	} | null {
 		const limit = this.limits.find((l) => l.endpoint === endpoint);
 		const queue = this.requestQueues.get(endpoint);
@@ -162,6 +217,70 @@ export class RateLimiterService {
 			remaining,
 			resetTime: queue.lastRequestTime + 60000,
 			dailyRemaining: limit.dailyLimit - queue.dailyCount,
+			circuitOpenUntil: this.circuitBreakers.get(endpoint)?.openUntil,
 		};
+	}
+
+	isRateLimitError(error: any): error is EulenRateLimitError {
+		return Boolean(error?.isEulenRateLimitError);
+	}
+
+	private assertCircuitClosed(endpoint: string): void {
+		const circuit = this.circuitBreakers.get(endpoint);
+		if (!circuit) return;
+
+		const now = Date.now();
+		if (circuit.openUntil <= now) {
+			this.circuitBreakers.delete(endpoint);
+			return;
+		}
+
+		const retryAfterMs = circuit.openUntil - now;
+		throw new EulenRateLimitError(
+			endpoint,
+			retryAfterMs,
+			`Eulen circuit is open for ${endpoint}. Next retry after ${Math.ceil(retryAfterMs / 1000)}s.`,
+		);
+	}
+
+	private openCircuit(endpoint: string, error: EulenRateLimitError): number {
+		const now = Date.now();
+		const previous = this.circuitBreakers.get(endpoint);
+		const strikes = (previous?.strikes || 0) + 1;
+		const providerRetryMs = Math.max(error.retryAfterMs || 0, this.defaultProviderRetryMs);
+		const exponentialMs = Math.min(
+			this.defaultProviderRetryMs * Math.pow(2, Math.max(0, strikes - 1)),
+			this.maxProviderRetryMs,
+		);
+		const jitterMs = Math.floor(Math.random() * 2500);
+		const retryAfterMs = Math.min(
+			Math.max(providerRetryMs, exponentialMs) + jitterMs,
+			this.maxProviderRetryMs,
+		);
+
+		this.circuitBreakers.set(endpoint, {
+			openUntil: now + retryAfterMs,
+			strikes,
+			lastReason: error.message,
+			lastOpenedAt: now,
+		});
+
+		this.logger.warn(
+			`Eulen circuit opened for ${endpoint}: retry in ${Math.ceil(retryAfterMs / 1000)}s (strike ${strikes})`,
+		);
+
+		return retryAfterMs;
+	}
+
+	private closeCircuit(endpoint: string): void {
+		if (this.circuitBreakers.delete(endpoint)) {
+			this.logger.log(`Eulen circuit closed for ${endpoint}`);
+		}
+	}
+
+	private getPositiveNumberFromEnv(key: string, fallback: number): number {
+		const raw = process.env[key];
+		const parsed = raw ? Number(raw) : NaN;
+		return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 	}
 }

--- a/Atlas-API/src/services/transaction-status-sync.service.ts
+++ b/Atlas-API/src/services/transaction-status-sync.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service';
-import { TransactionStatus } from '@prisma/client';
+import { PayerMatchStatus, TransactionStatus } from '@prisma/client';
 import { EulenClientService } from './eulen-client.service';
+import { EulenRateLimitError } from './rate-limiter.service';
+import { IdentityVaultService } from '../identity-vault/identity-vault.service';
 
 @Injectable()
 export class TransactionStatusSyncService {
@@ -12,6 +14,7 @@ export class TransactionStatusSyncService {
 	constructor(
 		private readonly prisma: PrismaService,
 		private readonly eulenClient: EulenClientService,
+		private readonly identityVaultService: IdentityVaultService,
 	) {}
 
 	/**
@@ -85,6 +88,12 @@ export class TransactionStatusSyncService {
 					await new Promise(resolve => setTimeout(resolve, 500));
 				} catch (error) {
 					errors++;
+					if (error instanceof EulenRateLimitError || error?.isEulenRateLimitError) {
+						this.logger.warn(
+							`Eulen deposit-status sync deferred by rate limit: ${error.message}`,
+						);
+						break;
+					}
 					this.logger.error(
 						`Failed to sync transaction ${transaction.id}: ${error.message}`,
 					);
@@ -190,21 +199,53 @@ export class TransactionStatusSyncService {
 
 			// Only update if status actually changed
 			if (newStatus && newStatus !== transaction.status) {
-				const currentMetadata = await this.prisma.transaction
+				const currentTransaction = await this.prisma.transaction
 					.findUnique({
 						where: { id: transaction.id },
-						select: { metadata: true },
-					})
-					.then((tx) => (tx?.metadata ? JSON.parse(tx.metadata) : {}));
+						select: {
+							metadata: true,
+							merchantContact: {
+								include: { identity: true },
+							},
+						},
+					});
+				const currentMetadata = currentTransaction?.metadata
+					? JSON.parse(currentTransaction.metadata)
+					: {};
+				let payerMatchStatus: PayerMatchStatus | undefined;
+
+				if (payerInfo) {
+					const session = currentMetadata.sessionToken
+						? await this.prisma.paymentLinkSession.findUnique({
+								where: { sessionToken: currentMetadata.sessionToken },
+							})
+						: null;
+					const identityResult =
+						await this.identityVaultService.upsertMerchantContactFromPayment({
+							merchantId: transaction.userId,
+							transactionId: transaction.id,
+							payerName: payerInfo.payerName,
+							payerTaxNumber: payerInfo.payerTaxNumber,
+							payerEuid: payerInfo.payerEUID,
+							expectedTaxNumber: session?.payerTaxNumber,
+							expectedEuid: currentTransaction?.merchantContact?.identity?.euid,
+						});
+					payerMatchStatus = identityResult.matchStatus;
+					if (identityResult.matchStatus === PayerMatchStatus.MISMATCH) {
+						newStatus = TransactionStatus.IN_REVIEW;
+					}
+				}
 
 				await this.prisma.transaction.update({
 					where: { id: transaction.id },
 					data: {
 						status: newStatus,
 						processedAt: new Date(),
+						payerMatchStatus,
 						metadata: JSON.stringify({
 							...currentMetadata,
 							...payerInfo,
+							payerMatchStatus,
 							syncedAt: new Date().toISOString(),
 							syncedVia: 'cron-job',
 							eulenStatus: eulenStatusString,
@@ -229,6 +270,9 @@ export class TransactionStatusSyncService {
 			}
 		} catch (error) {
 			// Log but don't throw - continue with other transactions
+			if (error instanceof EulenRateLimitError || error?.isEulenRateLimitError) {
+				throw error;
+			}
 			this.logger.error(
 				`Error checking transaction ${transaction.id} with Eulen: ${error.message}`,
 			);

--- a/Atlas-API/src/webhooks/webhook.service.ts
+++ b/Atlas-API/src/webhooks/webhook.service.ts
@@ -15,10 +15,12 @@ import {
 	PixPaymentWebhookDto,
 } from '../common/dto/webhook.dto';
 import { TransactionStatus } from '@prisma/client';
+import { PayerMatchStatus } from '@prisma/client';
 import { BotSyncService } from '../common/services/bot-sync.service';
 import { WebhookService as PaymentLinkWebhookService } from '../payment-link/webhook.service';
 import { ExternalWebhookService } from '../external-api/external-webhook.service';
 import { EmailService } from '../services/email.service';
+import { IdentityVaultService } from '../identity-vault/identity-vault.service';
 
 @Injectable()
 export class WebhookService {
@@ -34,6 +36,7 @@ export class WebhookService {
 		@Inject(forwardRef(() => ExternalWebhookService))
 		private readonly externalWebhookService: ExternalWebhookService,
 		private readonly emailService: EmailService,
+		private readonly identityVaultService: IdentityVaultService,
 	) {}
 
 	/**
@@ -106,6 +109,9 @@ export class WebhookService {
 				},
 				include: {
 					user: true,
+					merchantContact: {
+						include: { identity: true },
+					},
 				},
 			});
 
@@ -124,7 +130,7 @@ export class WebhookService {
 
 			// Map Eulen status to our transaction status
 			const previousStatus = transaction.status;
-			const newStatus = this.mapEulenStatusToTransactionStatus(
+			let newStatus = this.mapEulenStatusToTransactionStatus(
 				eventData.status,
 			);
 
@@ -150,6 +156,35 @@ export class WebhookService {
 			const existingMetadata = transaction.metadata
 				? JSON.parse(transaction.metadata)
 				: {};
+			let identityResult: { matchStatus: PayerMatchStatus } | null = null;
+
+			if (
+				(newStatus === TransactionStatus.PROCESSING ||
+					newStatus === TransactionStatus.COMPLETED) &&
+				(eventData.payerEUID || eventData.payerTaxNumber || eventData.payerName)
+			) {
+				const session = existingMetadata.sessionToken
+					? await this.prisma.paymentLinkSession.findUnique({
+							where: { sessionToken: existingMetadata.sessionToken },
+						})
+					: null;
+
+				identityResult =
+					await this.identityVaultService.upsertMerchantContactFromPayment({
+						merchantId: transaction.userId,
+						transactionId: transaction.id,
+						payerName: eventData.payerName,
+						payerTaxNumber: eventData.payerTaxNumber,
+						payerEuid: eventData.payerEUID,
+						expectedTaxNumber: session?.payerTaxNumber,
+						expectedEuid: transaction.merchantContact?.identity?.euid,
+					});
+
+				if (identityResult.matchStatus === PayerMatchStatus.MISMATCH) {
+					newStatus = TransactionStatus.IN_REVIEW;
+				}
+			}
+
 			const updatedMetadata = {
 				...existingMetadata,
 				webhookEvent: {
@@ -163,6 +198,7 @@ export class WebhookService {
 					pixKey: eventData.pixKey,
 					valueInCents: eventData.valueInCents,
 					eulenStatus: eventData.status,
+					payerMatchStatus: identityResult?.matchStatus,
 					webhookReceivedAt: new Date().toISOString(),
 				},
 			};
@@ -179,7 +215,9 @@ export class WebhookService {
 							? new Date()
 							: transaction.processedAt,
 					errorMessage:
-						newStatus === TransactionStatus.FAILED
+						identityResult?.matchStatus === PayerMatchStatus.MISMATCH
+							? 'Webhook: payer identity mismatch'
+							: newStatus === TransactionStatus.FAILED
 							? `Webhook: ${eventData.status}`
 							: null,
 					updatedAt: new Date(),

--- a/Atlas-API/src/withdrawals/withdrawals.service.ts
+++ b/Atlas-API/src/withdrawals/withdrawals.service.ts
@@ -15,6 +15,7 @@ import { CouponsService } from '../coupons/coupons.service';
 import { ValidateCouponDto } from '../coupons/dto/coupon.dto';
 import { LwkService } from '../services/lwk.service';
 import { EulenClientService } from '../services/eulen-client.service';
+import { EulenRateLimitError } from '../services/rate-limiter.service';
 
 @Injectable()
 export class WithdrawalsService {
@@ -553,12 +554,22 @@ export class WithdrawalsService {
 	@Cron(CronExpression.EVERY_MINUTE)
 	async pollEulenWithdrawals() {
 		try {
+			const now = new Date();
 			const processing = await this.prisma.withdrawalRequest.findMany({
 				where: {
 					status: WithdrawalStatus.PROCESSING,
 					eulenWithdrawalId: { not: null },
+					OR: [
+						{ eulenNextPollAt: null },
+						{ eulenNextPollAt: { lte: now } },
+					],
 				},
 				include: { user: { select: { id: true, email: true, username: true } } },
+				orderBy: [
+					{ eulenNextPollAt: 'asc' },
+					{ updatedAt: 'asc' },
+				],
+				take: 20,
 			});
 
 			if (processing.length === 0) return;
@@ -594,7 +605,12 @@ export class WithdrawalsService {
 							}
 						}
 
-						const updateData: any = { eulenSplits: updatedSplits };
+						const updateData: any = {
+							eulenSplits: updatedSplits,
+							eulenPollAttempts: { increment: 1 },
+							eulenNextPollAt: null,
+							eulenRateLimitedAt: null,
+						};
 
 						if (anyFailed) {
 							updateData.status = WithdrawalStatus.FAILED;
@@ -629,7 +645,12 @@ export class WithdrawalsService {
 					} else {
 						// Single withdrawal (no splits)
 						const eulenStatus = await this.eulenClient.getWithdrawStatus(w.eulenWithdrawalId!);
-						const updateData: any = { eulenStatus: eulenStatus.status };
+						const updateData: any = {
+							eulenStatus: eulenStatus.status,
+							eulenPollAttempts: { increment: 1 },
+							eulenNextPollAt: null,
+							eulenRateLimitedAt: null,
+						};
 
 						if (eulenStatus.status === 'sent') {
 							updateData.status = WithdrawalStatus.COMPLETED;
@@ -660,12 +681,35 @@ export class WithdrawalsService {
 						});
 					}
 				} catch (error) {
-					this.logger.error(`[WITHDRAWAL] Eulen polling error for ${w.id}: ${error.message}`);
+					await this.handleEulenPollingError(w.id, error);
 				}
 			}
 		} catch (error) {
 			this.logger.error(`[WITHDRAWAL] Eulen polling cron error: ${error.message}`);
 		}
+	}
+
+	private async handleEulenPollingError(withdrawalId: string, error: any) {
+		if (error instanceof EulenRateLimitError || error?.isEulenRateLimitError) {
+			const retryAfterMs = Math.max(error.retryAfterMs || 60_000, 60_000);
+			const nextPollAt = new Date(Date.now() + retryAfterMs);
+
+			await this.prisma.withdrawalRequest.update({
+				where: { id: withdrawalId },
+				data: {
+					eulenNextPollAt: nextPollAt,
+					eulenRateLimitedAt: new Date(),
+					eulenPollAttempts: { increment: 1 },
+				},
+			});
+
+			this.logger.warn(
+				`[WITHDRAWAL] Eulen polling rate-limited for ${withdrawalId}; next poll at ${nextPollAt.toISOString()}`,
+			);
+			return;
+		}
+
+		this.logger.error(`[WITHDRAWAL] Eulen polling error for ${withdrawalId}: ${error.message}`);
 	}
 
 	/**

--- a/Atlas-Panel/app/components/AccountValidationModal.tsx
+++ b/Atlas-Panel/app/components/AccountValidationModal.tsx
@@ -23,6 +23,8 @@ export default function AccountValidationModal({
   const [validationAmount, setValidationAmount] = useState<number>(2.0);
   const [useCustomWallet, setUseCustomWallet] = useState(false);
   const [customDepixAddress, setCustomDepixAddress] = useState('');
+  const [taxNumber, setTaxNumber] = useState('');
+  const [fullName, setFullName] = useState('');
   const [qrCodeData, setQrCodeData] = useState<{
     qrCode: string;
     pixKey: string;
@@ -58,6 +60,8 @@ export default function AccountValidationModal({
         setQrCodeData(null);
         setPaymentStatus('idle');
         setCustomDepixAddress('');
+        setTaxNumber('');
+        setFullName('');
         setUseCustomWallet(false);
         setCopied(false);
       }, 300);
@@ -168,9 +172,20 @@ export default function AccountValidationModal({
       return;
     }
 
+    const cleanTaxNumber = taxNumber.replace(/\D/g, '');
+    if (cleanTaxNumber.length !== 11 && cleanTaxNumber.length !== 14) {
+      toast.error('Informe um CPF/CNPJ valido');
+      return;
+    }
+
+    if (!fullName.trim()) {
+      toast.error('Informe o nome completo');
+      return;
+    }
+
     setLoading(true);
     try {
-      const payment = await accountValidationService.createValidationPayment(walletToUse);
+      const payment = await accountValidationService.createValidationPayment(walletToUse, cleanTaxNumber, fullName.trim());
 
       if (payment.qrCode && typeof payment.qrCode === 'string' && payment.qrCode.length > 0) {
         // Generate QR Code image
@@ -263,6 +278,34 @@ export default function AccountValidationModal({
                 </div>
               </div>
 
+              <div>
+                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+                  CPF/CNPJ do titular *
+                </label>
+                <input
+                  type="text"
+                  value={taxNumber}
+                  onChange={(e) => setTaxNumber(e.target.value.replace(/\D/g, '').slice(0, 14))}
+                  className="w-full px-3 sm:px-4 py-2.5 sm:py-3 bg-[var(--bg-secondary)] border border-[var(--border-hover)] text-[var(--text-primary)] text-sm sm:text-base rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 placeholder-[var(--text-muted)]"
+                  placeholder="00000000000 ou 00000000000000"
+                  disabled={loading}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+                  Nome completo *
+                </label>
+                <input
+                  type="text"
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                  className="w-full px-3 sm:px-4 py-2.5 sm:py-3 bg-[var(--bg-secondary)] border border-[var(--border-hover)] text-[var(--text-primary)] text-sm sm:text-base rounded-lg focus:outline-none focus:ring-2 focus:ring-yellow-500 placeholder-[var(--text-muted)]"
+                  placeholder="Nome completo do pagador"
+                  disabled={loading}
+                />
+              </div>
+
               {/* Custom Wallet Toggle - Only show if user has default wallet */}
               {defaultWallet && (
                 <div className="flex items-center justify-between p-3 sm:p-4 bg-[var(--bg-secondary)] rounded-lg gap-3">
@@ -320,7 +363,7 @@ export default function AccountValidationModal({
                   type="button"
                   onClick={handleValidationPayment}
                   className="w-full sm:flex-1 px-4 py-3 bg-gradient-to-r from-yellow-600 to-orange-600 hover:from-yellow-700 hover:to-orange-700 active:from-yellow-800 active:to-orange-800 text-[var(--text-primary)] text-sm sm:text-base rounded-lg transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation"
-                  disabled={loading || (!defaultWallet && !customDepixAddress) || (useCustomWallet && !customDepixAddress)}
+                  disabled={loading || taxNumber.replace(/\D/g, '').length < 11 || !fullName.trim() || (!defaultWallet && !customDepixAddress) || (useCustomWallet && !customDepixAddress)}
                 >
                   {loading ? (
                     <div className="flex items-center justify-center gap-2">

--- a/Atlas-Panel/app/components/QRCodeGenerator.tsx
+++ b/Atlas-Panel/app/components/QRCodeGenerator.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { api, isAuxiliarCollaborator } from '@/app/lib/api';
 import { toast } from 'sonner';
 import {
@@ -30,12 +30,24 @@ interface GeneratedQR {
   status: 'pending' | 'completed' | 'expired';
 }
 
+interface ContactSuggestion {
+  id: string;
+  displayName: string;
+  taxNumberMasked: string | null;
+  status: string;
+  lastSuccessfulPaymentAt: string | null;
+}
+
 export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps) {
   const [formData, setFormData] = useState({
     amount: '',
     payerCpf: '',
+    payerName: '',
     walletAddress: defaultWallet || ''
   });
+  const [contactSuggestions, setContactSuggestions] = useState<ContactSuggestion[]>([]);
+  const [selectedContact, setSelectedContact] = useState<ContactSuggestion | null>(null);
+  const [isSearchingContacts, setIsSearchingContacts] = useState(false);
   const [useCustomWallet, setUseCustomWallet] = useState(false);
 
   const [isGenerating, setIsGenerating] = useState(false);
@@ -86,6 +98,40 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
     }
   };
 
+  useEffect(() => {
+    const query = formData.payerCpf || formData.payerName;
+    if (selectedContact || query.trim().length < 2) {
+      setContactSuggestions([]);
+      return;
+    }
+
+    const timeout = setTimeout(async () => {
+      setIsSearchingContacts(true);
+      try {
+        const response = await api.get('/identity-vault/contacts/search', {
+          params: { q: query.trim() }
+        });
+        setContactSuggestions(response.data || []);
+      } catch (error) {
+        setContactSuggestions([]);
+      } finally {
+        setIsSearchingContacts(false);
+      }
+    }, 250);
+
+    return () => clearTimeout(timeout);
+  }, [formData.payerCpf, formData.payerName, selectedContact]);
+
+  const selectContact = (contact: ContactSuggestion) => {
+    setSelectedContact(contact);
+    setContactSuggestions([]);
+    setFormData({
+      ...formData,
+      payerName: contact.displayName,
+      payerCpf: ''
+    });
+  };
+
   const handleGenerateQR = async () => {
     if (!formData.amount || parseFloat(formData.amount.replace(',', '.')) <= 0) {
       toast.error('Digite um valor válido');
@@ -95,7 +141,7 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
     // Validate amount limits (Commerce Mode: NO level limits, only max per transaction)
     const amountValue = parseFloat(formData.amount.replace(',', '.'));
     const minAmount = 1;
-    const maxAmount = formData.payerCpf ? 5000 : 3000;
+    const maxAmount = 5000;
 
     if (amountValue < minAmount) {
       toast.error(`Valor mínimo permitido: R$ ${minAmount.toFixed(2)}`);
@@ -107,9 +153,16 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
       return;
     }
 
-    if (formData.payerCpf && !validateCPF(formData.payerCpf)) {
-      toast.error('CPF/CNPJ inválido');
-      return;
+    if (!selectedContact) {
+      if (!formData.payerName.trim()) {
+        toast.error('Informe o nome completo do pagador');
+        return;
+      }
+
+      if (!validateCPF(formData.payerCpf)) {
+        toast.error('CPF/CNPJ inválido');
+        return;
+      }
     }
 
     // Handle wallet validation
@@ -127,7 +180,9 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
     try {
       const payload = {
         amount: parseFloat(formData.amount.replace(',', '.')), // Handle comma decimal separator
-        payerCpfCnpj: formData.payerCpf ? formData.payerCpf.replace(/\D/g, '') : undefined,
+        payerContactId: selectedContact?.id,
+        payerTaxNumber: selectedContact ? undefined : formData.payerCpf.replace(/\D/g, ''),
+        payerFullName: selectedContact ? undefined : formData.payerName.trim(),
         depixAddress: useCustomWallet ? formData.walletAddress : defaultWallet,
         isCommerceRequest: true // Flag to indicate this is from commerce page, not deposit page
       };
@@ -217,8 +272,11 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
     setFormData({
       amount: '',
       payerCpf: '',
+      payerName: '',
       walletAddress: defaultWallet || ''
     });
+    setSelectedContact(null);
+    setContactSuggestions([]);
     setUseCustomWallet(false);
   };
 
@@ -269,8 +327,8 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
                 Aviso para Clientes Novos
               </p>
               <p className="text-yellow-700 dark:text-yellow-300/90 text-sm">
-                Clientes que nunca compraram DePix possuem um limite de <strong>R$ 500,00</strong> na primeira compra.
-                Após 24 horas da primeira transação, poderão realizar compras com os limites normais (até R$ 3.000 ou R$ 5.000 com CPF/CNPJ).
+                Para pagadores novos, informe CPF/CNPJ e nome completo. Depois do primeiro pagamento confirmado,
+                o contato ficará salvo para gerar novos QR Codes por sugestão.
               </p>
             </div>
           </div>
@@ -300,15 +358,34 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
               />
             </div>
             <p className="text-xs text-[var(--text-muted)] mt-1">
-              Limites: R$ 1,00 (mínimo) a R$ {formData.payerCpf ? '5.000,00' : '3.000,00'} {formData.payerCpf ? '(com CPF/CNPJ)' : '(sem CPF/CNPJ)'} por transação
+              Limites: R$ 1,00 (mínimo) a R$ 5.000,00 por transação identificada
             </p>
           </div>
 
 
-          {/* Payer CPF/CNPJ Input */}
+          {/* Payer Identity Inputs */}
           <div>
             <label className="block text-sm font-medium text-[var(--text-muted)] mb-2">
-              CPF/CNPJ do Pagador (opcional)
+              Nome completo do Pagador *
+            </label>
+            <div className="relative">
+              <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-[var(--text-muted)]" />
+              <input
+                type="text"
+                value={formData.payerName}
+                onChange={(e) => {
+                  setSelectedContact(null);
+                  setFormData({ ...formData, payerName: e.target.value });
+                }}
+                placeholder="Digite para buscar contato ou informar novo pagador"
+                className="w-full pl-10 pr-4 py-3 bg-[var(--bg-elevated)] border border-[var(--border-hover)] rounded-lg text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-[var(--text-muted)] mb-2">
+              CPF/CNPJ do Pagador *
             </label>
             <div className="relative">
               <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-[var(--text-muted)]" />
@@ -317,6 +394,7 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
                 value={formData.payerCpf}
                 onChange={(e) => {
                   const value = e.target.value.replace(/\D/g, '').slice(0, 14);
+                  setSelectedContact(null);
                   setFormData({ ...formData, payerCpf: value });
                 }}
                 placeholder="000.000.000-00 ou 00.000.000/0000-00"
@@ -324,9 +402,48 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
               />
             </div>
             <p className="text-xs text-[var(--text-muted)] mt-1">
-              Deixe em branco para aceitar pagamento de qualquer CPF/CNPJ (limite de R$ 3.000 por transação). Com CPF/CNPJ específico o limite é R$ 5.000
+              Digite nome ou CPF/CNPJ para buscar contatos já pagos; pagadores novos precisam de nome completo e documento.
             </p>
           </div>
+
+          {selectedContact && (
+            <div className="flex items-center justify-between gap-3 p-3 bg-green-100 dark:bg-green-500/10 border border-green-300 dark:border-green-500/30 rounded-lg">
+              <div>
+                <p className="text-sm font-medium text-green-700 dark:text-green-300">{selectedContact.displayName}</p>
+                {selectedContact.taxNumberMasked && (
+                  <p className="text-xs text-green-700 dark:text-green-400">{selectedContact.taxNumberMasked}</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedContact(null)}
+                className="text-sm text-green-700 dark:text-green-300 hover:underline"
+              >
+                Trocar
+              </button>
+            </div>
+          )}
+
+          {(isSearchingContacts || contactSuggestions.length > 0) && (
+            <div className="border border-[var(--border-hover)] rounded-lg overflow-hidden bg-[var(--bg-elevated)]">
+              {isSearchingContacts && (
+                <div className="px-4 py-3 text-sm text-[var(--text-muted)]">Buscando contatos...</div>
+              )}
+              {contactSuggestions.map((contact) => (
+                <button
+                  key={contact.id}
+                  type="button"
+                  onClick={() => selectContact(contact)}
+                  className="w-full px-4 py-3 text-left hover:bg-[var(--bg-secondary)] transition-colors border-t border-[var(--border-default)] first:border-t-0"
+                >
+                  <span className="block text-sm font-medium text-[var(--text-primary)]">{contact.displayName}</span>
+                  {contact.taxNumberMasked && (
+                    <span className="block text-xs text-[var(--text-muted)]">{contact.taxNumberMasked}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
 
           {/* Custom Wallet Toggle - Only show if user has default wallet AND is not AUXILIAR */}
           {defaultWallet && !isAuxiliarCollaborator() ? (
@@ -388,7 +505,7 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
           {/* Generate Button */}
           <button
             onClick={handleGenerateQR}
-            disabled={isGenerating || !formData.amount}
+            disabled={isGenerating || !formData.amount || (!selectedContact && (!formData.payerName.trim() || !formData.payerCpf))}
             className="w-full py-3 bg-[var(--accent)] text-[var(--text-primary)] rounded-lg font-medium hover:bg-[var(--accent-hover)] transition-all disabled:opacity-50 disabled:cursor-not-allowed transform hover:scale-105 active:scale-95"
           >
             {isGenerating ? (
@@ -472,10 +589,17 @@ export default function QRCodeGenerator({ defaultWallet }: QRCodeGeneratorProps)
                   </div>
 
 
-                  {formData.payerCpf && (
+                  {(selectedContact || formData.payerName) && (
+                    <div className="flex justify-between">
+                      <span className="text-[var(--text-muted)]">Pagador:</span>
+                      <span className="text-[var(--text-primary)]">{selectedContact?.displayName || formData.payerName}</span>
+                    </div>
+                  )}
+
+                  {(selectedContact?.taxNumberMasked || formData.payerCpf) && (
                     <div className="flex justify-between">
                       <span className="text-[var(--text-muted)]">CPF/CNPJ:</span>
-                      <span className="text-[var(--text-primary)]">{formatCPFCNPJ(formData.payerCpf)}</span>
+                      <span className="text-[var(--text-primary)]">{selectedContact?.taxNumberMasked || formatCPFCNPJ(formData.payerCpf)}</span>
                     </div>
                   )}
 

--- a/Atlas-Panel/app/lib/services.ts
+++ b/Atlas-Panel/app/lib/services.ts
@@ -19,13 +19,17 @@ export const accountValidationService = {
     return response.data;
   },
 
-  async createValidationPayment(depixAddress?: string): Promise<any> {
+  async createValidationPayment(depixAddress?: string, taxNumber?: string, fullName?: string): Promise<any> {
     const payload: any = {};
     if (depixAddress) {
       payload.depixAddress = depixAddress;
     }
-    // Note: EUID/tax number will be automatically extracted from the webhook
-    // when the user completes the PIX payment
+    if (taxNumber) {
+      payload.taxNumber = taxNumber;
+    }
+    if (fullName) {
+      payload.fullName = fullName;
+    }
     const response = await api.post('/account-validation/create-payment', payload);
     return response.data;
   },

--- a/Atlas-Panel/app/pay/[shortCode]/PaymentClient.tsx
+++ b/Atlas-Panel/app/pay/[shortCode]/PaymentClient.tsx
@@ -49,6 +49,8 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
   const [isExpired, setIsExpired] = useState(false);
   const [transactionId, setTransactionId] = useState<string | null>(null);
   const [taxNumber, setTaxNumber] = useState('');
+  const [payerFullName, setPayerFullName] = useState('');
+  const [needsFullName, setNeedsFullName] = useState(false);
   const [taxNumberError, setTaxNumberError] = useState('');
   const [needsTaxNumberForFixedAmount, setNeedsTaxNumberForFixedAmount] = useState(false);
 
@@ -213,6 +215,10 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
       setTaxNumberError('CPF/CNPJ inválido');
       return;
     }
+    if (needsFullName && !payerFullName.trim()) {
+      setTaxNumberError('Informe o nome completo para gerar o QR Code');
+      return;
+    }
 
     try {
       setIsGenerating(true);
@@ -224,6 +230,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
           body: JSON.stringify({
             amount: paymentData.isCustomAmount ? parseFloat(customAmount) : undefined,
             taxNumber: taxNumber.replace(/\D/g, ''),
+            fullName: payerFullName.trim() || undefined,
           }),
         }
       );
@@ -235,8 +242,16 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
       const data = await response.json();
       console.log('📦 QR Code with tax number generated:', data);
 
+      if (data.needsFullName) {
+        setNeedsFullName(true);
+        setTaxNumberError('Informe o nome completo para continuar');
+        setIsGenerating(false);
+        return;
+      }
+
       setQrCode(data.qrCode);
       setShowQrCode(true);
+      setNeedsFullName(false);
 
       // Store transaction ID
       if (data.transactionId) {
@@ -278,6 +293,10 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
       setTaxNumberError('CPF/CNPJ inválido');
       return;
     }
+    if (needsFullName && !payerFullName.trim()) {
+      setTaxNumberError('Informe o nome completo para gerar o QR Code');
+      return;
+    }
 
     try {
       setIsGenerating(true);
@@ -288,6 +307,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             taxNumber: taxNumber.replace(/\D/g, ''),
+            fullName: payerFullName.trim() || undefined,
           }),
         }
       );
@@ -299,9 +319,17 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
       const data = await response.json();
       console.log('📦 QR Code with tax number for fixed amount generated:', data);
 
+      if (data.needsFullName) {
+        setNeedsFullName(true);
+        setTaxNumberError('Informe o nome completo para continuar');
+        setIsGenerating(false);
+        return;
+      }
+
       setQrCode(data.qrCode);
       setShowQrCode(true);
       setNeedsTaxNumberForFixedAmount(false);
+      setNeedsFullName(false);
 
       // Store transaction ID
       if (data.transactionId) {
@@ -373,6 +401,29 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
     }
 
     return false;
+  };
+
+  const renderFullNameInput = () => {
+    if (!needsFullName) return null;
+
+    return (
+      <div className="animate-in slide-in-from-top-2 duration-300">
+        <input
+          type="text"
+          value={payerFullName}
+          onChange={(e) => {
+            setPayerFullName(e.target.value);
+            setTaxNumberError('');
+          }}
+          placeholder="Nome completo do pagador"
+          className="w-full px-4 py-3 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl text-[var(--text-primary)] text-center focus:outline-none focus:border-[var(--accent)] placeholder-[var(--text-muted)]"
+          style={{ fontSize: '16px' }}
+        />
+        <p className="text-xs text-[var(--text-muted)] mt-2 text-center">
+          Necessário apenas quando o CPF/CNPJ ainda não está salvo nos contatos do merchant.
+        </p>
+      </div>
+    );
   };
 
   const generateNewQRCode = async (amount?: number) => {
@@ -1007,7 +1058,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                       <div className="space-y-5">
                         <div className="text-center">
                           <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">Informe seu CPF/CNPJ</h3>
-                          <p className="text-sm text-[var(--text-secondary)]">Obrigatório para valores acima de R$ 3.000</p>
+                          <p className="text-sm text-[var(--text-secondary)]">Obrigatório para gerar o QR Code</p>
                         </div>
 
                         {/* Amount Display */}
@@ -1028,6 +1079,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                               onChange={(e) => {
                                 setTaxNumber(formatTaxNumber(e.target.value));
                                 setTaxNumberError('');
+                                setNeedsFullName(false);
                               }}
                               placeholder="CPF ou CNPJ"
                               className="w-full px-4 py-3 bg-transparent text-[var(--text-primary)] text-center focus:outline-none placeholder-[var(--text-muted)]"
@@ -1040,11 +1092,12 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                         {taxNumberError && (
                           <p className="text-red-400 text-xs text-center">{taxNumberError}</p>
                         )}
+                        {renderFullNameInput()}
 
                         {/* Submit Button */}
                         <button
                           onClick={generateWithTaxNumberForFixed}
-                          disabled={taxNumber.replace(/\D/g, '').length < 11 || isGenerating}
+                          disabled={taxNumber.replace(/\D/g, '').length < 11 || (needsFullName && !payerFullName.trim()) || isGenerating}
                           className="w-full relative group disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           <div className="hidden" />
@@ -1080,13 +1133,13 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                     <div className="py-6">
                       {(() => {
                         const currentAmount = parseAmount(customAmount);
-                        const taxThreshold = paymentData.minAmountForTaxNumber || 3000;
-                        const needsCpf = paymentData.requiresTaxNumber && currentAmount > taxThreshold;
+                        const needsCpf = true;
                         const isValidCpf = taxNumber.replace(/\D/g, '').length >= 11;
                         const canSubmit = currentAmount > 0 &&
                           (!paymentData.minAmount || currentAmount >= paymentData.minAmount) &&
                           (!paymentData.maxAmount || currentAmount <= paymentData.maxAmount) &&
-                          (!needsCpf || isValidCpf);
+                          isValidCpf &&
+                          (!needsFullName || payerFullName.trim().length > 0);
 
                         return (
                           <div className="space-y-5">
@@ -1195,6 +1248,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                                       onChange={(e) => {
                                         setTaxNumber(formatTaxNumber(e.target.value));
                                         setTaxNumberError('');
+                                        setNeedsFullName(false);
                                       }}
                                       placeholder="CPF ou CNPJ"
                                       className="w-full px-4 py-3 bg-transparent text-[var(--text-primary)] text-center focus:outline-none placeholder-[var(--text-muted)]"
@@ -1206,6 +1260,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                                 {taxNumberError && (
                                   <p className="text-red-400 text-xs mt-2 text-center">{taxNumberError}</p>
                                 )}
+                                {renderFullNameInput()}
                               </div>
                             )}
 
@@ -1420,7 +1475,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
             <div className="space-y-4">
               <div className="text-center">
                 <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">Informe seu CPF/CNPJ</h3>
-                <p className="text-sm text-[var(--text-secondary)]">Obrigatório para valores acima de R$ 3.000</p>
+                <p className="text-sm text-[var(--text-secondary)]">Obrigatório para gerar o QR Code</p>
               </div>
 
               {/* Amount Display */}
@@ -1442,6 +1497,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                     onChange={(e) => {
                       setTaxNumber(formatTaxNumber(e.target.value));
                       setTaxNumberError('');
+                      setNeedsFullName(false);
                     }}
                     placeholder="CPF ou CNPJ"
                     className="w-full px-4 py-3.5 bg-transparent text-[var(--text-primary)] text-center focus:outline-none placeholder-[var(--text-muted)]"
@@ -1454,11 +1510,12 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
               {taxNumberError && (
                 <p className="text-red-400 text-xs text-center">{taxNumberError}</p>
               )}
+              {renderFullNameInput()}
 
               {/* Submit Button */}
               <button
                 onClick={generateWithTaxNumberForFixed}
-                disabled={taxNumber.replace(/\D/g, '').length < 11 || isGenerating}
+                disabled={taxNumber.replace(/\D/g, '').length < 11 || (needsFullName && !payerFullName.trim()) || isGenerating}
                 className="w-full relative group disabled:opacity-50 disabled:active:scale-100"
               >
                 <div className="hidden" />
@@ -1493,13 +1550,13 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
             <div className="space-y-4">
               {(() => {
                 const currentAmount = parseAmount(customAmount);
-                const taxThreshold = paymentData.minAmountForTaxNumber || 3000;
-                const needsCpf = paymentData.requiresTaxNumber && currentAmount > taxThreshold;
+                const needsCpf = true;
                 const isValidCpf = taxNumber.replace(/\D/g, '').length >= 11;
                 const canSubmit = currentAmount > 0 &&
                   (!paymentData.minAmount || currentAmount >= paymentData.minAmount) &&
                   (!paymentData.maxAmount || currentAmount <= paymentData.maxAmount) &&
-                  (!needsCpf || isValidCpf);
+                  isValidCpf &&
+                  (!needsFullName || payerFullName.trim().length > 0);
 
                 return (
                   <>
@@ -1620,6 +1677,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                               onChange={(e) => {
                                 setTaxNumber(formatTaxNumber(e.target.value));
                                 setTaxNumberError('');
+                                setNeedsFullName(false);
                               }}
                               placeholder="CPF ou CNPJ"
                               className="w-full px-4 py-3.5 bg-transparent text-[var(--text-primary)] text-center focus:outline-none placeholder-[var(--text-muted)]"
@@ -1631,6 +1689,7 @@ export default function PaymentClient({ shortCode, initialData }: PaymentClientP
                         {taxNumberError && (
                           <p className="text-red-400 text-xs mt-2 text-center">{taxNumberError}</p>
                         )}
+                        {renderFullNameInput()}
                       </div>
                     )}
 

--- a/docs/plans/2026-06-15-eulen-identity-compliance.md
+++ b/docs/plans/2026-06-15-eulen-identity-compliance.md
@@ -1,0 +1,232 @@
+# Eulen identity compliance plan
+
+Date: 2026-06-15
+Branch: `issue-38-46-59-eulen-identity`
+Issues: zapix-labs/zapix-web-rebrand#38, #46, #59
+
+## Context
+
+The active implementation repo is `C:\Users\User\Documents\Zapix\Zapix_Web_Project\painel`, remote `atlasdao/painel`.
+The product issues live in `zapix-labs/zapix-web-rebrand`.
+
+Relevant current behavior:
+
+- `Atlas-API/src/services/eulen-client.service.ts` wraps Eulen calls with a simple per-endpoint rate limiter, but has no provider-driven backoff/circuit breaker for `520 Too many requests`.
+- `Atlas-API/src/withdrawals/withdrawals.service.ts` polls Eulen withdrawals every minute and has no persisted `nextPollAt`.
+- `Atlas-API/src/services/transaction-status-sync.service.ts` polls pending deposit status every minute and only uses a fixed 500 ms delay between transactions.
+- `Atlas-API/src/services/eulen-client.service.ts` only sends `endUserTaxNumber` when the value has 11 or 14 digits, so an EUID cannot be sent as `euid`.
+- `Atlas-API/src/pix/pix.service.ts` uses `verifiedTaxNumber` as if it were payer identity and sends it via `userTaxNumber`; for merchant QR this should become `merchantId`.
+- Payment link public generation only requires CPF/CNPJ above the old R$ 3000 threshold.
+- No Identity Vault / merchant contact model exists in Prisma today.
+
+## Goal
+
+Make Eulen webhook/status/polling reliable first, then implement merchant-scoped payer identities/contacts and QR generation with required payer identification plus merchant attribution.
+
+## Non-goals
+
+- Do not collect EUID manually from merchants or payers.
+- Do not implement a full CRM/contact CRUD beyond search/upsert needed for QR/payment-link flows.
+- Do not redesign withdrawal product UX; only implement the reliability controls required by #38.
+- Do not expose a global payer directory to merchants.
+
+## Assumptions
+
+- `User.verifiedTaxNumber` currently stores the validated Eulen EUID after onboarding; the new implementation will treat it as merchant EUID where it matches EUID shape.
+- Eulen deposit accepts `euid`, `endUserTaxNumber`, `endUserFullName`, `merchantId`, `whitelist`, and `delayDepixInHours`.
+- Payer full CPF/CNPJ may be stored only as a keyed hash plus masked version in the Identity Vault/contact tables; existing `Transaction.payerTaxNumber` and `PaymentLinkSession.payerTaxNumber` remain compatibility fields and will not be exposed in contact search.
+- The branch is now in Scene 1 implementation. Files in Scene 1 scope may be dirty because this plan is a live execution artifact, not a pristine pre-implementation snapshot.
+- The user explicitly requested one PR. Commit, push, and PR creation are authorized for the main thread after final verification; subagents remain read-only/review-only unless given a bounded write scope and must not push or publish.
+
+## PII and redaction contract
+
+- New identity/contact persistence stores payer CPF/CNPJ as `taxNumberHash` plus `taxNumberMasked`; full payer document is accepted only as request input and compatibility session metadata while the QR is generated.
+- Contact search responses must return `id`, `displayName`, `taxNumberMasked`, `lastSuccessfulPaymentAt`, `status`, and optional `payerEuid` only for backend QR payload assembly. The UI must never show full CPF/CNPJ.
+- Logs and audit payloads touched by this PR must redact `taxNumber`, `payerTaxNumber`, `payerCpfCnpj`, `endUserTaxNumber`, `euid`, `payerEUID`, `merchantId`, and nested payer payloads.
+- Existing historical raw metadata/audit rows are out of this PR and should be handled by a separate retention/scrub task if required.
+
+## API contract additions
+
+Payment link public request:
+
+- `POST /pay/:shortCode/validate-tax-number`
+- Body: `{ taxNumber: string, amount?: number, fullName?: string }`
+- Response extension: `{ needsFullName?: boolean, contactFound?: boolean, payerNameHint?: string, qrCode?: string, transactionId?: string, sessionToken?: string }`
+- Compatibility: old clients that send only `taxNumber` receive `needsFullName: true` instead of generating an unidentified QR when no merchant contact exists.
+
+Manual QR authenticated request:
+
+- Existing payload gains `payerContactId?: string`, `payerTaxNumber?: string`, `payerFullName?: string`.
+- Existing `payerCpfCnpj` is accepted as a backwards-compatible alias for `payerTaxNumber`.
+- No request accepts `payerEuid` from the browser.
+
+Identity contacts:
+
+- `GET /identity-vault/contacts/search?q=<name-or-doc-fragment>`
+- Authenticated and merchant-scoped by effective user id.
+- Response exposes only masked documents.
+
+Eulen deposit payload:
+
+- Saved contact with EUID: send `{ euid, merchantId }`.
+- New payer: send `{ endUserTaxNumber, endUserFullName, merchantId }`.
+- Never send an EUID as `endUserTaxNumber`.
+
+## Migration files
+
+- Scene 1 withdrawal polling: `Atlas-API/prisma/migrations/20260615_add_eulen_withdrawal_polling.sql`
+- Scene 2 identity vault: `Atlas-API/prisma/migrations/20260615_add_identity_vault.sql`
+- Rollback SQL if needed: additive rollback snippets go in `docs/plans/2026-06-15-eulen-identity-compliance.md` under final notes unless the repo already has a matching rollback convention for that migration area.
+
+## Scene Roadmap
+
+### Scene 1: #38 Eulen reliability
+
+Write scope:
+
+- `Atlas-API/src/services/rate-limiter.service.ts`
+- `Atlas-API/src/services/eulen-client.service.ts`
+- `Atlas-API/src/services/transaction-status-sync.service.ts`
+- `Atlas-API/src/withdrawals/withdrawals.service.ts`
+- `Atlas-API/prisma/schema.prisma`
+- migration SQL for withdrawal polling fields
+- focused service tests
+
+Objective:
+
+- Add provider-driven rate-limit detection, retry-after parsing, exponential backoff, jitter, circuit breaker by endpoint, observable rate-limit events, and persisted withdrawal `nextPollAt`.
+- Env/config defaults:
+  - `EULEN_RATE_LIMIT_DEFAULT_RETRY_MS` default `60000`.
+  - `EULEN_RATE_LIMIT_MAX_RETRY_MS` default `900000`.
+
+Checks:
+
+- Focused Jest tests for Eulen rate-limit/backoff and withdrawal polling skip.
+- `npm run build` in `Atlas-API`.
+
+Stop conditions:
+
+- Backoff sleeps cannot make unit tests slow.
+- Circuit breaker must not convert business errors into retries.
+
+### Scene 2: #46 Identity Vault backend
+
+Write scope:
+
+- `Atlas-API/prisma/schema.prisma`
+- migration SQL for identity/contact tables
+- `Atlas-API/src/identity-vault/**`
+- module imports
+- backend tests
+
+Objective:
+
+- Add internal payer identity and merchant-scoped contact records with hashed CPF/CNPJ, masked document, EUID, canonical/search names, per-merchant search, and webhook/status upsert helpers.
+- Add transaction identity references and match status when needed for expected-vs-actual payer comparison.
+
+Checks:
+
+- Unit tests for tax hash/mask/search scope/mismatch comparison.
+- Prisma validation or build.
+
+Stop conditions:
+
+- Any endpoint that allows cross-merchant contact search.
+- Any response exposing full CPF/CNPJ.
+
+### Scene 3: #59 QR/payment flows
+
+Write scope:
+
+- `Atlas-API/src/services/eulen-client.service.ts`
+- `Atlas-API/src/pix/**`
+- `Atlas-API/src/payment-link/**`
+- `Atlas-API/src/account-validation/**`
+- `Atlas-API/src/webhooks/**`
+- focused backend tests
+
+Objective:
+
+- Extend QR contracts with `payerTaxNumber`, `payerFullName`, `payerEuid`, `merchantId`, `identitySource`, and Eulen payload builder behavior:
+  - saved payer contact sends `euid`;
+  - new payer sends `endUserTaxNumber + endUserFullName`;
+  - merchant QR sends `merchantId` from stored merchant EUID.
+- Payment link always collects payer CPF/CNPJ before QR; asks for full name only when contact lookup cannot resolve it.
+- Webhook/status upserts contact only when payer identity matches expected EUID or tax document comparison.
+
+Checks:
+
+- Unit tests for Eulen payload builder.
+- Integration-style service tests for payment link needs-name and contact reuse paths.
+
+Stop conditions:
+
+- Manual EUID input.
+- QR generated for merchant without payer identity.
+- EUID sent as `endUserTaxNumber`.
+
+### Scene 4: Frontend flows
+
+Write scope:
+
+- `Atlas-Panel/app/components/QRCodeGenerator.tsx`
+- `Atlas-Panel/app/pay/[shortCode]/PaymentClient.tsx`
+- `Atlas-Panel/app/components/AccountValidationModal.tsx`
+- `Atlas-Panel/app/lib/services.ts`
+- frontend build fixes
+
+Objective:
+
+- Add contact suggestions by name/CPF for manual QR.
+- Add full-name prompt in payment links only when backend returns `needsFullName`.
+- Add onboarding CPF/CNPJ/name fields where validation payment is created.
+
+Checks:
+
+- `npm run build` in `Atlas-Panel`.
+- Browser smoke on the affected screens if the app can start locally without external services.
+
+Stop conditions:
+
+- UI asks for EUID.
+- Suggestions show full CPF/CNPJ.
+
+### Scene 5: Final verification and PR
+
+Write scope:
+
+- tests only if final reviewers find gaps
+- PR body
+
+Objective:
+
+- Run focused and broad checks, review git hygiene, commit, push branch, and open one PR with exact summary and CI/pre-merge test recommendations.
+
+Checks:
+
+- `git diff --check`
+- backend focused Jest
+- backend build
+- frontend build
+- final reviewer/sweeper gates
+
+Rollback strategy:
+
+- Schema changes are additive.
+- Eulen backoff/circuit parameters are env-configurable.
+- QR identity enforcement can degrade to collecting CPF/CNPJ + full name when contact/EUID is unavailable.
+
+Rollback SQL snippets:
+
+- Scene 1:
+  - `DROP INDEX IF EXISTS "WithdrawalRequest_eulenNextPollAt_idx";`
+  - `ALTER TABLE "WithdrawalRequest" DROP COLUMN IF EXISTS "eulenNextPollAt", DROP COLUMN IF EXISTS "eulenPollAttempts", DROP COLUMN IF EXISTS "eulenRateLimitedAt";`
+- Scene 2:
+  - Drop new Identity Vault FKs/indexes/tables only after disabling dual-write paths.
+
+## Status log
+
+- 2026-06-15: CMV loaded and MAPO selected.
+- 2026-06-15: Clean branch created from `main`.
+- 2026-06-15: Issues #38, #46, #59 verified open in GitHub.
+- 2026-06-15: Plan Gate rejected initial plan; plan updated with live dirty state, exact API additions, migration files, PII redaction scope, env defaults, and main-thread PR authorization.


### PR DESCRIPTION
## Summary

Implements Eulen identity compliance and reliability work for the three linked issues:

- Resolves zapix-labs/zapix-web-rebrand#38
- Resolves zapix-labs/zapix-web-rebrand#46
- Resolves zapix-labs/zapix-web-rebrand#59

## What changed

### #38 - Eulen webhook/status/polling reliability
- Added provider-aware `EulenRateLimitError` handling with retry-after parsing, endpoint circuit state, and capped backoff defaults.
- Added Eulen withdrawal polling persistence fields: `eulenNextPollAt`, `eulenPollAttempts`, `eulenRateLimitedAt`.
- Updated withdrawal polling to skip rate-limited items until their next eligible poll time instead of hammering Eulen.
- Updated transaction status sync to stop the current batch cleanly on Eulen rate-limit/circuit errors.
- Added focused unit coverage for Eulen rate-limit circuit behavior.

### #46/#59 - Merchant contacts and required payer identity for QR creation
- Added Identity Vault models/migration for payer identities, merchant contacts, identity events, payer match status, masked/hash document metadata, and transaction/session links.
- Added `GET /identity-vault/contacts/search?q=...` scoped by merchant account context.
- Manual commerce QR now requires either a saved merchant contact with EUID or CPF/CNPJ + full payer name for a new payer.
- Payment links now require payer CPF/CNPJ before QR generation; if no saved contact/EUID exists, backend returns `needsFullName` and generates QR only after full name is provided.
- After payment confirmation, webhook/status sync upserts the merchant contact using payer name, censored/returned document, and payer EUID from Eulen.
- Mismatch between expected payer identity and actual Eulen payload moves the transaction to `IN_REVIEW` instead of silently approving.
- Account validation/onboarding now collects CPF/CNPJ + full name before creating the validation QR, stores the merchant EUID from Eulen `payerEUID`, and rejects validation if Eulen returns missing/mismatched payer identity.
- External API QR creation now requires CPF/CNPJ + full name instead of allowing unidentified QR creation.
- Eulen deposit payload builder now sends:
  - saved payer contact: `euid` plus merchant `merchantId`
  - new payer: `endUserTaxNumber` + `endUserFullName` plus merchant `merchantId`
  - never sends an EUID as `endUserTaxNumber`
- Added recursive sensitive redaction for logs/audit payloads covering CPF/CNPJ, EUID, payer identity fields, tokens, and nested Eulen payloads.

### Frontend
- Commerce manual QR supports contact suggestions by typing name or CPF/CNPJ and sends `payerContactId` for saved payers.
- Commerce manual QR collects full payer name + CPF/CNPJ for new payers.
- Public payment link checkout handles `needsFullName` and re-submits CPF/CNPJ + name before QR generation.
- Account validation modal now requires CPF/CNPJ + full name before generating the validation QR.

## Verification performed

- `cd Atlas-API && npx prisma validate`
- `cd Atlas-API && npx prisma generate`
- `cd Atlas-API && npm run build`
- `cd Atlas-API && npm run test:unit -- --runInBand rate-limiter.service.spec.ts identity-vault.utils.spec.ts`
- `cd Atlas-Panel && npm run build`

Panel build completes with existing warnings about multiple lockfiles, async WASM target, and legacy `metadata.viewport` usage.

## Recommended CI / pre-merge gates

1. Prisma schema/migration gate:
   - `cd Atlas-API && npx prisma validate`
   - apply the two new SQL migrations against a disposable Postgres database
   - run `npx prisma generate`
2. API gate:
   - `cd Atlas-API && npm run build`
   - focused unit tests: `npm run test:unit -- --runInBand rate-limiter.service.spec.ts identity-vault.utils.spec.ts`
3. Panel gate:
   - `cd Atlas-Panel && npm run build`
4. Contract/integration smoke tests to add before merge if time allows:
   - payment link: tax-only request returns `needsFullName` for unknown payer
   - payment link: known contact sends EUID path and does not request name again
   - manual commerce QR: saved contact sends `payerContactId` path
   - manual commerce QR: new payer requires CPF/CNPJ + full name
   - webhook/status: mismatched payer moves transaction to `IN_REVIEW`
   - onboarding validation: missing/mismatched Eulen payer identity does not validate merchant
5. Longer-term CI cleanup:
   - current broad `npm run test:unit -- --runInBand` is not a reliable gate because legacy specs still fail on stale Admin/Pix expectations, real Eulen calls, and Jest/nanoid ESM parsing. Those should be fixed in a separate test-infra PR before making the full suite required.